### PR TITLE
svg text selectable feature implemented

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "dev"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "dev"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 
 ## Unreleased
 
-### `Changed`
+### Added ability to select and copy text in a tree
 
-- Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
+- The SVG text is not selectable and could be copied. This makes it easy for researchers to highlight elements of interest such as accession number, etc. This is both valid for interactive mode and even during SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
+- The text selection cursor symbol changes from hand (before) to a pipe symbol (`|`) in both the webapp GUI and SVG image export. Injected CSS style in svg tag which is much safer on line 453: `svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}>"); `
 
 ### `Added`
-
+- Added text selection of tree text including distance values and leaf nodes text in both webapp and SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
 - Metadata fields have been added to inner and outer node labels. [PR 4](https://github.com/phac-nml/ArborView/pull/3)
 
 - Cladeogram tree layout. [PR 2](https://github.com/phac-nml/ArborView/pull/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 
 ### Added ability to select and copy text in a tree
 
-- The SVG text is not selectable and could be copied. This makes it easy for researchers to highlight elements of interest such as accession number, etc. This is both valid for interactive mode and even during SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
-- The text selection cursor symbol changes from hand (before) to a pipe symbol (`|`) in both the webapp GUI and SVG image export. Injected CSS style in svg tag which is much safer on line 453: `svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}>"); `
+- The SVG text is not selectable and could be copied. This makes it easy for researchers to highlight elements of interest such as accession number, etc. This is both valid for interactive mode and even during SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8). Speciicaly, the text selection cursor symbol changes from hand (before) to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. Injected the CSS style in the `<svg>` tag which is much safer and permanent solution available for both SVG image exports and webapp
 
 ### `Added`
 - Added text selection of tree text including distance values and leaf nodes text in both webapp and SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 
 ## Unreleased
 
-### Added ability to select and copy text in a tree
+### `Changed`
 
-- The SVG text is not selectable and could be copied. This makes it easy for researchers to highlight elements of interest such as accession number, etc. This is both valid for interactive mode and even during SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8). Speciicaly, the text selection cursor symbol changes from hand (before) to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. Injected the CSS style in the `<svg>` tag which is much safer and permanent solution available for both SVG image exports and webapp
-
+- Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
+  
+- Text selection cursor symbol changes from hand to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. [PR 8](https://github.com/phac-nml/ArborView/pull/8)
+  
 ### `Added`
 - Added text selection of tree text including distance values and leaf nodes text in both webapp and SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
+
 - Metadata fields have been added to inner and outer node labels. [PR 4](https://github.com/phac-nml/ArborView/pull/3)
 
 - Cladeogram tree layout. [PR 2](https://github.com/phac-nml/ArborView/pull/2)

--- a/html/table.html
+++ b/html/table.html
@@ -114,7 +114,7 @@
         const __DEADFOOD__ = 0xDEADF00D;
         var test_newick = "((BGIOSIFCE006902.1_ORYSA:0.652945[&&NHX:S=ORYSA],(At4g19560.1_ARATH:0.566484[&&NHX:S=ARATH],(At4g19600.1_ARATH:0.229647[&&NHX:S=ARATH],At5g45190.1_ARATH:0.149569[&&NHX:S=ARATH]):0.109796[&&NHX:S=ARATH:SIS=100:D=Y:B=100]):0.283052[&&NHX:S=ARATH:SIS=100:D=Y:B=100]):0.930921[&&NHX:S=Magnoliophyta:D=N:B=100],((((((((((((CCNK_HUMAN:0.001351[&&NHX:S=HUMAN],CCNK_F3_PANTR:0.001588[&&NHX:S=PANTR]):0.009317[&&NHX:S=Homo/Pan/Gorilla_group:D=N:B=100],CCNK_MACMU:0.01227[&&NHX:S=MACMU]):0.020339[&&NHX:S=Catarrhini:D=N:B=100],(CCNK_BOVIN:0.049478[&&NHX:S=BOVIN],CCNK_CANFA:0.076883[&&NHX:S=CANFA]):0.026972[&&NHX:S=Laurasiatheria:D=N:B=97]):0.01376[&&NHX:S=Eutheria:D=N:B=62],(Ccnk_MOUSE:0.018183[&&NHX:S=MOUSE],LOC500715_RAT:0.02728[&&NHX:S=RAT]):0.054247[&&NHX:S=Murinae:D=N:B=100]):0.087752[&&NHX:S=Eutheria:D=N:B=65],CCNK_MONDO:0.069457[&&NHX:S=MONDO]):0.053263[&&NHX:S=Theria:D=N:B=83],NP_001026380_CHICK:0.085022[&&NHX:S=CHICK]):0.059401[&&NHX:S=Amniota:D=N:B=80],CCNK_XENTR:0.175799[&&NHX:S=XENTR]):0.075577[&&NHX:S=Tetrapoda:D=N:B=97],((si_dkey-60a16_F2_BRARE:0.143195[&&NHX:S=BRARE],(CCNK_TETNG:0.142629[&&NHX:S=TETNG],CCNK_F2_GASAC:0.115749[&&NHX:S=GASAC]):0.130837[&&NHX:S=Percomorpha:D=N:B=100]):0.077038[&&NHX:S=Clupeocephala:D=N:B=95],ENSGACT00000017400_GASAC:0.40355[&&NHX:S=GASAC]):0.058401[&&NHX:S=Clupeocephala:SIS=33:D=Y:B=13]):0.233994[&&NHX:S=Euteleostomi:D=N:B=18],(ENSCINT00000017473_CIOIN:0[&&NHX:S=CIOIN],ENSCINT00000026852_CIOIN:0.002343[&&NHX:S=CIOIN]):0.481407[&&NHX:S=CIOIN:SIS=100:D=Y:B=100]):0.090892[&&NHX:S=Chordata:D=N:B=98],((CycK-RA_DROME:0.17719[&&NHX:S=DROME],dper_GLEANR_8777_caf1_DROPE:0.174477[&&NHX:S=DROPE]):0.199588[&&NHX:S=Sophophora:D=N:B=100],(AAEL013531-RA_AEDAE:0.214131[&&NHX:S=AEDAE],XP_317464_ANOGA:0.204436[&&NHX:S=ANOGA]):0.178396[&&NHX:S=Culicidae:D=N:B=100]):0.293157[&&NHX:S=Diptera:D=N:B=100]):0.104694[&&NHX:S=Coelomata:D=N:B=98],Smp_130980_SCHMA:0.624197[&&NHX:S=SCHMA]):0.041513[&&NHX:S=Bilateria:D=N:B=84],(WBGene00009650_CAEEL:0.186775[&&NHX:S=CAEEL],(CBG04574_CAEBR:0.21279[&&NHX:S=CAEBR],cr01.sctg48.wum.67.1_CAERE:0.192611[&&NHX:S=CAERE]):0.076335[&&NHX:S=Caenorhabditis:D=N:B=86]):1.18006[&&NHX:S=Caenorhabditis:D=N:B=86]):0.311276[&&NHX:S=Bilateria:D=N:B=84])[&&NHX:S=Eukaryota:D=N:B=0];";
         const TREE = __DEADBEEF__;
-        // the '= __DEADFOOD__' is an expression to find and replace and inline tsv string e.g. 'head1\thead2\nv1\tv2\n'
+        // the '= __DEADFOOD__' is an expression to find and replace and inline tsv string e.g. 'head1\thead2\nv1\tv2\n's
         const DATA = __DEADFOOD__;
         const DEBUG = false;
         const TREE_OFFSET = 100;
@@ -220,7 +220,11 @@
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
                     .attr("width", width) //makes sure all tree nodes are within view
-                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: none;`)
+                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`)
+                
+                svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}"); 
+
+
                 const gLink = svg.append("g")
                     .attr("fill", "none")
                     .attr("stroke", "#555")
@@ -449,8 +453,10 @@
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
                     .attr("width", width + 20) //makes sure all tree nodes are within view
-                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`) //user-select:auto makes text selectable
-                svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}>");    
+                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`) 
+
+                svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");    
+                
                 const gLink = svg.append("g")
                     .attr("fill", "none")
                     .attr("stroke", "#555")
@@ -710,7 +716,10 @@
                 .attr("id", "TreeSVG")
                 .attr("viewBox", [0, 0, width, height])
                 .attr("font-family", "sans-serif")
-                .attr("font-size", 10);
+                .attr("font-size", 10)
+                .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`);
+            
+            svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");  
 
             const gNode = svg.append("g")
                 .attr("cursor", "pointer")
@@ -977,7 +986,10 @@
                     .attr("id", "TreeSVG")
                     .attr("width", width + 20) //makes sure all tree nodes are within view
                     .attr("height", dx)
-                    .attr("style", `width:${width}px; height: auto; font: 10px sans-serif; user-select: none;`)
+                    .attr("style", `width:${width}px; height: auto; font: 10px sans-serif; user-select: auto;`)
+
+                
+                svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");   
 
                 const gLink = svg.append("g")
                     .attr("fill", "none")

--- a/html/table.html
+++ b/html/table.html
@@ -70,6 +70,8 @@
             animation: updown 1s ease infinite
         }
 
+        
+
 
     </style>
     
@@ -219,7 +221,6 @@
                     .attr("id", "TreeSVG")
                     .attr("width", width) //makes sure all tree nodes are within view
                     .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: none;`)
-                    
                 const gLink = svg.append("g")
                     .attr("fill", "none")
                     .attr("stroke", "#555")
@@ -448,8 +449,8 @@
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
                     .attr("width", width + 20) //makes sure all tree nodes are within view
-                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: none;`)
-                    
+                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`) //user-select:auto makes text selectable
+                svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}>");    
                 const gLink = svg.append("g")
                     .attr("fill", "none")
                     .attr("stroke", "#555")


### PR DESCRIPTION
The SVG text is not selectable and could be copied. This makes it easy for researchers to highlight elements of interest such as accession number, etc. This is both valid for interactive mode and even during SVG image exports