### PR TITLE
Update/svg export remove text duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Text selection cursor symbol changes from hand to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. [PR 8](https://github.com/phac-nml/ArborView/pull/8)
   
 ### `Added`
+- Added duplicated `<text>` tags removal during SVG image export from the tree leaf nodes for accurate keyword searches on an resulting SVG image [PR 10] (https://github.com/phac-nml/ArborView/pull/10)
+
 - Added text selection of tree text including distance values and leaf nodes text in both webapp and SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
 
 - Metadata fields have been added to inner and outer node labels. [PR 4](https://github.com/phac-nml/ArborView/pull/3)

--- a/html/table.html
+++ b/html/table.html
@@ -2358,7 +2358,14 @@
             let downloadLink = document.createElement("a");
             downloadLink.download = 'tree_snapshot_'+date.getDate()+'-'+
                 (date.getMonth()+1)+'-'+date.getFullYear()+'_'+date.getHours()+'h.svg';
-            let svg =  document.getElementById("TreeData")    
+            let svg =  document.getElementById("TreeData").cloneNode(true)
+            //remove duplicated leaf nodes text duplication for more accurate searches
+            svg.querySelectorAll('g .tree-node').forEach(node => {
+                text_nodes_leafs = node.querySelectorAll('text[class=""]')
+                if(text_nodes_leafs.length === 2){
+                    text_nodes_leafs[0].remove()
+                }
+            })  
             const blob = serialize2svg(svg)[0];
             downloadLink.href = window.URL.createObjectURL(blob);
             downloadLink.click(); //Trigger a click on the element


### PR DESCRIPTION
There was a small modification of the `export_tree_to_svg` function that now removes duplicated text entries from the copy of the `<svg>` element. This allows for more accurate search number counts instead of duplicated values. This is a temporary fix of duplicated and even triplicated text tags in the tree nodes.

