### PR TITLE
Copy selected node IDs to the clipboard functionality implemented and better IDs button tooltip message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### `Changed`
 
 - Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
+- Changed the `IDs` button hoverover tip message to reflect the new copy leaf node identifiers to the clipboard functionality [PR 11](https://github.com/phac-nml/ArborView/pull/11)
 
 ### `Added`
 
@@ -14,3 +15,6 @@
 - Cladeogram tree layout. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
 
 - Added slider for adjusting line thickness. [PR 5](https://github.com/phac-nml/ArborView/pull/5)
+
+- Added copy tree nodes to the clipboard [PR 11](https://github.com/phac-nml/ArborView/pull/11)
+

--- a/html/table.html
+++ b/html/table.html
@@ -2455,7 +2455,7 @@
                     if (result.state === "granted" || result.state === "prompt") {
 		                navigator.clipboard.writeText(text2copy)
                         Swal.fire({
-                            html: `<p>Copied ${text2copyArray.length} nodes to clipboard<br>Generate a text file?</p>`,
+                            html: `<p>Successfully copied ${text2copyArray.length} node IDs to the clipboard<br>Generate a text file with the ${text2copyArray.length} IDs?</p>`,
                             icon: "info",
                             showDenyButton: true,
                             showCancelButton: false,
@@ -2463,28 +2463,26 @@
                             denyButtonText: 'No'
                         }).then( (result) => {
                             if (result.isConfirmed) {
-                                Swal.fire('Saved!', '', 'success')
-                            } else if (result.isDenied) {
-                                Swal.fire('Changes are not saved', '', 'info')
+                                let success_msg = `Copied ${text2copyArray.length} sample IDs to the clipboard`
+                                if(DEBUG){
+                                    console.log(text2copy);
+                                }
+                                let file = new File(["\ufeff"+text2copy], 'selectedNodes.txt', {type: "text/plain:charset=UTF-8"})
+                                //create a ObjectURL in order to download the created file
+                                url = window.URL.createObjectURL(file);
+                                let a = document.createElement("a");
+                                a.style = "display: none";
+                                a.href = url;
+                                a.download = file.name;
+                                a.click();
+                                window.URL.revokeObjectURL(url);
                             }
                         });
                     }    
                    
                 });
 
-                let success_msg = `copied ${text2copyArray.length} sample IDs to the clipboard`
-                if(DEBUG){
-                    console.log(text2copy);
-                }
-                let file = new File(["\ufeff"+text2copy], 'selectedNodes.txt', {type: "text/plain:charset=UTF-8"})
-                //create a ObjectURL in order to download the created file
-                url = window.URL.createObjectURL(file);
-                let a = document.createElement("a");
-                a.style = "display: none";
-                a.href = url;
-                a.download = file.name;
-                a.click();
-                window.URL.revokeObjectURL(url);
+                
             }
             else{
                 Swal.fire({
@@ -2577,7 +2575,7 @@
                                 
                                 <div class="d-flex flex-row align-items-center p-0 text-left">
                                     <button class="flex-grow-1 btn-sm btn-primary text-break me-1 mb-1" data-toggle="tooltip" data-placement="top"  
-                                        title="Copy selected node ID's to your clipboard to paste into another application." onclick="copy_ids_to_clipboard()" name="CopyIDs" id="copy-ids-button">
+                                        title="Copy selected node IDs to your clipboard to paste into another application and optionally generate a text file" onclick="copy_ids_to_clipboard()" name="CopyIDs" id="copy-ids-button">
                                         <i class="bi bi-clipboard me-1"></i>IDs
                                     </button>
                                     <button class="flex-grow-1 btn-sm btn-primary text-break me-1 mb-1" data-toggle="tooltip" data-placement="top" 

--- a/html/table.html
+++ b/html/table.html
@@ -2449,20 +2449,50 @@
                 }
                 text2copyArray.push(node.textContent)
             })
-            let text2copy = text2copyArray.join('\n');
-            let success_msg = `copied ${text2copyArray.length} sample IDs to the clipboard`
-            if(DEBUG){
-                console.log(text2copy);
+            if(text2copyArray.length > 0){
+                let text2copy = text2copyArray.join('\n');
+                navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
+                    if (result.state === "granted" || result.state === "prompt") {
+		                navigator.clipboard.writeText(text2copy)
+                        Swal.fire({
+                            html: `<p>Copied ${text2copyArray.length} nodes to clipboard<br>Generate a text file?</p>`,
+                            icon: "info",
+                            showDenyButton: true,
+                            showCancelButton: false,
+                            confirmButtonText: 'Yes',
+                            denyButtonText: 'No'
+                        }).then( (result) => {
+                            if (result.isConfirmed) {
+                                Swal.fire('Saved!', '', 'success')
+                            } else if (result.isDenied) {
+                                Swal.fire('Changes are not saved', '', 'info')
+                            }
+                        });
+                    }    
+                   
+                });
+
+                let success_msg = `copied ${text2copyArray.length} sample IDs to the clipboard`
+                if(DEBUG){
+                    console.log(text2copy);
+                }
+                let file = new File(["\ufeff"+text2copy], 'selectedNodes.txt', {type: "text/plain:charset=UTF-8"})
+                //create a ObjectURL in order to download the created file
+                url = window.URL.createObjectURL(file);
+                let a = document.createElement("a");
+                a.style = "display: none";
+                a.href = url;
+                a.download = file.name;
+                a.click();
+                window.URL.revokeObjectURL(url);
             }
-            let file = new File(["\ufeff"+text2copy], 'selectedNodes.txt', {type: "text/plain:charset=UTF-8"})
-            //create a ObjectURL in order to download the created file
-            url = window.URL.createObjectURL(file);
-            let a = document.createElement("a");
-            a.style = "display: none";
-            a.href = url;
-            a.download = file.name;
-            a.click();
-            window.URL.revokeObjectURL(url);        
+            else{
+                Swal.fire({
+                    html: "<b>No nodes to copy and export!</b><p>Select tree node(s) first and try again</p>",
+                    icon: "error"
+                    });
+                
+            }            
         }
 
         vertical_div_resize = function(event){


### PR DESCRIPTION
The users asked to write selected node identifiers not only to the text file, but also copy them to the clipboard (Task # `STRY0016780`). This functionality was implemented allowing now users both to copy node identifiers to the system clipboard and optionally generate a text file by responding to the alert popup dialog messages.

In addition, improved tooltip `IDs` button message stating that both clipboard and file generation is possible from the selected node IDs (Task #: `STRY0017484`).