### PR TITLE
release 0.1.1 improving scale bar and adding nodes annotation with metadata

### DIFF
--- a/html/table.html
+++ b/html/table.html
@@ -690,7 +690,7 @@
                         .attr("text-anchor", d => !d.data.leaf ? "end" : "start")
                         .attr("class", d => d.data.leaf ? "" : "inner-node-label")
                         .style("visibility", d => d.data.leaf ? "" : SHOW_METADATA_IN_NAME ? "visible" : "hidden")
-                        .text(d => d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name )
+                        .text(d => d.data.meta ? d.data.name ? `${d.data.name} | ${d.data.meta}` : d.data.meta : d.data.name )
                         .clone(true).lower()
                         .attr("stroke", "white");
                     
@@ -977,7 +977,7 @@
                         .attr("class", d => d.data.leaf ? "" : "inner-node-label")
                         .text(d => {
                             // If meta is a string or name is defined for the node
-                            return d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name
+                            return d.data.meta ? d.data.name ? `${d.data.name} | ${d.data.meta}` : d.data.meta : d.data.name
                         })
                         .clone(true).lower()
                         .attr("stroke", "white");
@@ -1295,7 +1295,7 @@
                         return hyp}) // labels are not bein moved to the correct pos when redrawn
                     .attr("class", d => d.data.leaf ? "" : "inner-node-label")
                     .style("visibility", d => d.data.leaf ? "" : SHOW_METADATA_IN_NAME ? "visible" : "hidden")
-                    .text(d => d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name )
+                    .text(d => d.data.meta ? d.data.name ? `${d.data.name} | ${d.data.meta}` : d.data.meta : d.data.name )
                     .clone(true).lower()
                     .attr("font-size", "12")
                     .attr("stroke-linejoin", "round")
@@ -1507,7 +1507,7 @@
                         .attr("x", d => !d.data.leaf ? -6 : 6)
                         .style("visibility", d => d.data.leaf ? "" : SHOW_METADATA_IN_NAME ? "visible" : "hidden")
                         .attr("class", d => d.data.leaf ? "" : "inner-node-label")
-                        .text(d => d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name )
+                        .text(d => d.data.meta ? d.data.name ? `${d.data.name} | ${d.data.meta}` : d.data.meta : d.data.name )
                         .clone(true).lower()
                         .attr("stroke-linejoin", "round")
                         .attr("stroke-width", 3)
@@ -1690,11 +1690,11 @@
                 // and re-colour selected ones
                 $(SelectedNodes.selection_id).empty().append(() => {
                     let attributes = new Array;
-                    for(const item of SelectedNodes.nodes.keys()){
+                    for(const [, nodeElement] of SelectedNodes.nodes.entries()){
                         attributes.push(`<div class="d-flex border-bottom align-items-center selected-node">
-                        <div onclick="scroll_into_view_treenode('${item}')" class="flex-grow-1">${item}</div>
+                        <div onclick="scroll_into_view_treenode('${nodeElement.id}')" class="flex-grow-1">${nodeElement.id}</div>
                         <div>
-                            <button onclick="remove_selected_node(this.dataset.nodeId)" data-node-id="${item}" 
+                            <button onclick="remove_selected_node(this.dataset.nodeId)" data-node-id="${nodeElement.id}" 
                             class="btn btn-danger m-1 btn-sm">x</button>
                         </div>
                         </div>\n`);
@@ -1949,7 +1949,6 @@
                 $("#TreeData").append(svg_chart);
                 $(".leaf-node").each((i, elm) => {
                     // Maintain colour of already selected nodes
-
                     let [parent, circle, text] = SelectedNodes.getNodeData(elm);
                     if(SelectedNodes.nodes.has(text.textContent)){
                         SelectedNodes.nodes.set(text.textContent, parent); // update to new parent
@@ -2025,7 +2024,7 @@
                 $(".leaf-node").each((i, elm) => {
                 let [parent, circle, text] = SelectedNodes.getNodeData(elm);
                 if(SelectedNodes.nodes.has(text.textContent)){
-                        SelectedNodes.nodes.set(text.textContent, parent); // reset dom postion
+                        SelectedNodes.nodes.set(text.textContent, parent); // reset dom position
                         SelectedNodes.setSelectedColours(text, circle);
                     };
                 });
@@ -2128,6 +2127,8 @@
             // Retrieve the rendering function from TREE_SWITCH based on current selection
             // E.g. dendrogram_chart(), tidytree_chart(), dendrogram_circle(), cladeogram_chart()
             const treeRendererFunction = TREE_SWITCH.get(TREE_VAL);
+            console.debug(`Applying rendering function ${treeRendererFunction.name}()`)
+
             if (typeof treeRendererFunction !== "function") {
                 console.error("Invalid tree renderer function selected:", TREE_VAL);
                 return false;
@@ -2403,7 +2404,6 @@
          * @returns {void}
          */
         let initialize_legend_menu = () => {
-            console.log("initialize legend menu")
             const buttonIds = ["#legend_dropdown_button", "#metadata_fields_dropdown_button"];
 
             buttonIds.forEach(id => {
@@ -2451,6 +2451,48 @@
             })
             $("#dropdown_tree_types").append(tree_types.join("\n"))
 
+        }
+
+        /**
+         * Updates the text labels of all rendered leaf nodes in the existing D3 SVG tree.
+         * 
+         * Each leaf node is expected to be a <g> element with the class `leaf-node` and an `id`
+         * corresponding to the sample ID. The label is updated in the format: `<sampleID> | <joinedFields>`.
+         * 
+         * This function does not re-render the tree — it modifies the existing DOM structure.
+         * 
+         * @param {Map<string, string>} allDataMap - A map of sample IDs to metadata strings (joined fields),
+         *                                           where the key is the leaf node ID and the value is the new label content.
+         * 
+         * @example
+         * const MetaDataMap = new Map([
+         *   ["SRR13243498", "Canada"],
+         *   ["SRR13243499", "USA"]
+         * ]);
+         * updateLeafNodeLabels(MetaDataMap);
+         */
+         function updateLeafNodeLabels(MetaDataMap) {
+            const svg = d3.select("#TreeSVG");
+            if (svg.empty()) {
+                console.warn("Tree SVG not found.");
+                return;
+            }
+
+            svg.selectAll("g.leaf-node").each(function () {
+                const g = d3.select(this);
+                const nodeId = this.id;
+
+                const joinedFields = MetaDataMap.get(nodeId);
+                const hasValue = typeof joinedFields === "string" && joinedFields.trim() !== "";
+                const newLabel = hasValue ? `${nodeId} | ${joinedFields.trim()}` : nodeId;
+
+                g.selectAll("text")
+                    .filter(function () {
+                        // Only update text elements that start with the nodeId
+                        return d3.select(this).text().startsWith(nodeId);
+                    })
+                    .text(newLabel);
+            });
         }
 
         /**
@@ -2512,14 +2554,14 @@
 
                     
                     // Extract all metadata already loaded as a map
-                    const metadataJoined = extractAllMetadataJoined(checkedFields);
-
-                    console.log(checkedFields,TABLE_HEADERS, metadataJoined)
+                    const metadataJoinedMap = extractAllMetadataJoined(checkedFields);
         
                     // Append metadata to tree leaf nodes if available
-                    if (metadataJoined.size !== 0) {
-                        tree_root = annotateLeafNodesWithMeta(tree_root, metadataJoined);
-                        redrawTree()
+                    if (metadataJoinedMap.size !== 0) {
+                        //tree_root = annotateLeafNodesWithMeta(tree_root, metadataJoinedMap);
+                        updateLeafNodeLabels(metadataJoinedMap)
+                        //redrawTree()
+
                     }else{
                         console.warn("The metadata table map is empty.");
                     }
@@ -2606,7 +2648,7 @@
                         const link = document.createElement('a');
                         link.className = 'dropdown-item';
                         link.href = '#';
-                        link.id = `legend-item-${index + 1}`;
+                        link.id = `${index + 1}`;
                         link.textContent = field;
                         link.setAttribute('onclick', 'colour_by_element(this)');
                         dropdown.appendChild(link);
@@ -2640,6 +2682,7 @@
                 unq_data.add(value[col_index])
             })
 
+
             // Need to create groupings of the each set of ID's belonging to each value grouping
             let break_down_values = Array.from(unq_data);
             break_down_values.sort()
@@ -2651,7 +2694,7 @@
 
             let colours = randomColor({luminosity: 'dark', count: Object.keys(break_down_values).length, seed: 42, format: "hex"});
         
-            /* Heuristic alogrithm to pick non-overlapping colours above threshold */ 
+            /* Heuristic algorithm to pick non-overlapping colours above threshold */ 
             
             //given a random colours for legend items find highly similar colours below the deltaE2000 threshold
             if(colours.length <= 50){
@@ -2742,7 +2785,7 @@
                     $(".leaf-node").each((i, elm) => {
                         let [parent, circle, text] = SelectedNodes.getNodeData(elm);
                         if(SelectedNodes.nodes.has(text.textContent)){
-                            SelectedNodes.nodes.set(text.textContent, parent); // reset dom postion
+                            SelectedNodes.nodes.set(text.textContent, parent); // reset dom position
                             SelectedNodes.setSelectedColours(text, circle);
                     };
                 });
@@ -3012,9 +3055,7 @@
             })
         }
 
-        legend_on_off = function(node){
-            console.debug(node.checked)
-            
+        legend_on_off = function(node){        
             if(node.checked === false){
                 document.querySelector('#colour-legend').classList.add("d-none");
             }else{

--- a/html/table.html
+++ b/html/table.html
@@ -6,6 +6,11 @@
             display: inline-block;
         }
 
+        .row.no-wrap {
+            flex-wrap: nowrap;
+            overflow-x: auto;
+        }
+
         .scrollbar-window{
             overflow: auto;
             /*overflow-x: scroll;*/
@@ -27,6 +32,7 @@
             cursor: pointer;
         }
 
+       
 
         .scale-bar {
             cursor: move;
@@ -2171,15 +2177,37 @@
                 console.error("Invalid tree renderer function selected:", TREE_VAL);
                 return false;
             }
-        
-            let renderedTree = treeRendererFunction(tree_root);      
+            
+            console.log(document.querySelector('#TreeData').offsetHeight, 
+            document.querySelector('#control_panel').offsetHeight)
+            let renderedTree = treeRendererFunction(tree_root); 
+            //Match #TreeData height
+            const treeDataHeight = document.querySelector('#TreeData').offsetHeight;
+            const treeData = document.querySelector('#TreeData');
+            treeData.style.height = `${treeDataHeight}px`;
+            
             renderedTree.style.paddingLeft = renderedTree.style.paddingLeft + TREE_OFFSET;
+            console.log(document.querySelector('#TreeData').offsetHeight, 
+            document.querySelector('#control_panel').offsetHeight)
+            
             
             // Insert rendered svg tree into the DOM
             $("#TreeData").append(renderedTree);
+            console.log(document.querySelector('#TreeData').offsetHeight, 
+            document.querySelector('#control_panel').offsetHeight)
+
+            
+            
+
+            //const treeHeight = document.querySelector('#TreeData').offsetHeight;
+            //const menuHeight = document.querySelector('#tree_menu_buttons').offsetHeight;
+
+            //const availableHeight = treeHeight - menuHeight;
+            //console.log(availableHeight)
 
             // Resize the side panel to match tree height
-            document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
+            //console.log(`${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`)
+            //document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
             // Scroll to center horizontally
             document.querySelector('#TreeData').scrollTo(document.querySelector('#TreeData').scrollWidth/2,0)
         };
@@ -2282,6 +2310,22 @@
         };
 
         /**
+         * Recalculates and applies the height of the #SelectedNodes panel
+         * based on the current size of #TreeData and #tree_menu_buttons.
+         */
+        function adjustSelectedNodesHeight() {
+            const treeData = document.querySelector('#TreeData');
+            const menuButtons = document.querySelector('#tree_menu_buttons');
+            const selectedNodes = document.querySelector('#SelectedNodes');
+            if (!treeData || !menuButtons || !selectedNodes) return;
+
+            const availableHeight = treeData.offsetHeight - menuButtons.clientHeight-8;
+            // Optionally guard against too-small values:
+            const minHeight = 100; 
+            selectedNodes.style.height = `${Math.max(availableHeight, minHeight)}px`;
+        }
+
+        /**
          * Creates and populates an HTML table with parsed metadata, then initializes a DataTable.
          *
          * This function removes existing UI elements related to loading and metadata selection,
@@ -2318,6 +2362,7 @@
             $(table_id).html("<thead>" + table_head + "</thead>" + "<tbody>" + table_body.join() + "</tbody>");
             // ? A bit odd we are making the table with HTML then converting to jquery datatable...
             CreateDataTable();
+            adjustSelectedNodesHeight();
         };
 
         let CreateColoringGroups = (array_vals) => {
@@ -2536,7 +2581,11 @@
                     })
                     .text(newLabel);
             });
+            
         }
+
+
+       
 
         /**
          * Attaches event listeners to all metadata checkboxes in the 
@@ -2569,17 +2618,21 @@
             }
             labels.forEach(label => {
                 label.addEventListener('click', (event) => {
+                   
                     const checkbox = label.querySelector('input[type="checkbox"]');
                     if (!checkbox) return;
+                    console.log(checkbox, event.target.tag, checkbox.checked )
                     
-                    // Only manually toggle if click was NOT directly on the checkbox area
-                    if (event.target !== checkbox) {
-                        if (checkbox.checked  === false) {
-                            checkbox.checked = true;
-                        }else{
-                            checkbox.checked = false;
-                    }
-                       
+                    
+                    
+                    // If the actual target was the checkbox, let native behavior proceed
+                    // Otherwise use manual checkbox turn on
+                    if (event.target === checkbox) {
+                        // Let the browser handle toggle if user clicks on input box directly
+                    } else {
+                        // Manually toggle if click was on label (not checkbox)
+                        event.preventDefault(); // prevent default label toggle double click
+                        checkbox.checked = !checkbox.checked;
                     }
 
                     // Log checked and unchecked fields
@@ -3395,17 +3448,28 @@
             }            
         }
 
+        
         document.addEventListener("DOMContentLoaded",()=>{
             let button = document.querySelector('#tree_fullscreen_btn')
 
-            /*document.querySelector('#TreeData').addEventListener("fullscreenchange", (event) => {
-                
-                if(button.classList.contains("d-none")){
-                    button.classList.remove('d-none')
-                }else{
-                    button.classList.add('d-none')
-                }
-            })*/
+           /**
+             * Handles dynamic layout adjustments when the #ClusterInfo section is shown or hidden.
+             *
+             * The code manages layout changes triggered by toggling the #ClusterInfo collapsible metadata panel 
+             * (e.g., by clicking on the blue bar), ensuring proper height distribution among surrounding elements.
+             *
+             * When the panel is collapsed or expanded, it adjusts the height of:
+             *  - #TreeData: the main tree visualization container
+             *  - #control_panel: the left-side control panel
+             *  - #SelectedNodes: the panel showing selected tree nodes (via max-height)
+             *
+             * This ensures that when the metadata panel is hidden, the freed vertical space is redistributed to 
+             * other visible panels, allowing them to expand and fully utilize the viewport.
+             *
+             * It relies on inline styles and consistent height units (e.g., px) to compute and apply the new layout.
+             * Designed to enhance UI responsiveness and usability when toggling metadata visibility.
+             *
+             */
 
             document.querySelector('#ClusterInfo').addEventListener('hidden.bs.collapse', function () {
                 let heightMetaDiv = document.querySelector('#ClusterInfo>div').style.height
@@ -3414,7 +3478,9 @@
                 document.querySelector('#TreeData').style.height= parseFloat(heightTreeDataDiv) + parseFloat(heightMetaDiv)+unit
                 document.querySelector('#control_panel').style.height = parseFloat(heightTreeDataDiv) + parseFloat(heightMetaDiv)+unit
                 document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
-            })
+                adjustSelectedNodesHeight()
+            }) 
+
             document.querySelector('#ClusterInfo').addEventListener('show.bs.collapse', function () {
                 let heightMetaDiv = document.querySelector('#ClusterInfo>div').style.height
                 let heightTreeDataDiv = document.querySelector('#TreeData').style.height
@@ -3422,10 +3488,17 @@
                 document.querySelector('#TreeData').style.height= parseFloat(heightTreeDataDiv) - parseFloat(heightMetaDiv)+unit
                 document.querySelector('#control_panel').style.height = parseFloat(heightTreeDataDiv) - parseFloat(heightMetaDiv)+unit
                 document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
+                adjustSelectedNodesHeight()
             })
 
     
         });    
+
+
+        // Call once DOM is ready
+        document.addEventListener("DOMContentLoaded", () => {
+            initializeClusterInfoToggleBehavior();
+        });
 
 
         clear_selected_nodes = function(){
@@ -3513,16 +3586,14 @@
             function stop_resize(event){
                 document.removeEventListener('mousemove', resize)
                 document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
-            }    
+            }   
+            
         }
         document.addEventListener('mouseup',(event)=>{
                 document.removeEventListener('mousemove', vertical_div_resize,false)
+                adjustSelectedNodesHeight() 
         })
-    window.onload = function(){
-        let heightSelectedNodesPanel = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
-        document.querySelector('#SelectedNodes').style.cssText = `height: ${heightSelectedNodesPanel}; max-height: ${heightSelectedNodesPanel} `
-
-    }    
+    
 
     //The Bootstrap dropdown-menu position absolute css is not working and menu is obscured by other divs
     //This fixes the issue as we do not want to modify original BS code
@@ -3552,7 +3623,7 @@
 </head>
     <body>
         <div class="container-fluid m-0">
-            <div class="row"> <!-- id="TreeSelections" style=""-->
+            <div class="row no-wrap"> <!-- id="TreeSelections" style=""-->
                 <div id="control_panel" class="col-2 border border-primary px-1 overflow-auto">
                     <div id="tree_menu_buttons" class="row m-0">
                                 <div class="d-flex flex-row align-items-stretch p-0 text-left mt-1 mb-1">
@@ -3724,9 +3795,8 @@
             
                     <div data-toggle="tooltip" data-placement="top" 
                         title="Selected nodes on the tree will show up here." 
-                        style="max-height: 10vh;"
                         class="col border border-primary p-1 w-100 Tree inline-block-child scrollbar-window" 
-                        id="SelectedNodes">
+                        id="SelectedNodes" style="height: 15vh;">
                         <div class="d-flex h-100 text-center text-uppercase text-center">
                             <small class="align-self-center w-100">Selected Nodes</small>
                         </div>        
@@ -3736,7 +3806,7 @@
 
                 <div class="position-relative p-0 bg-white col-10 Tree inline-block-child scrollbar-window" 
                 onscroll="scroll_legend_into_view(document.querySelector('#colour-legend'), document.querySelector('#tree_fullscreen_btn'), this)"
-                id="TreeData" style="height:70vh;">
+                id="TreeData">
 
                         <div id="tree-splash" class="fs-2 d-flex justify-content-center align-items-center" style="height:50vh;"><i class="bi bi-tree"></i> Your tree will show up here when loaded!</div>
                         

--- a/html/table.html
+++ b/html/table.html
@@ -314,16 +314,16 @@
 
         function drawScale(svg, length, height, max_length, root){
             /**
-             * Draws a scale bar in a dendrogram or phylogenetic tree visualization,
-             * indicating tree distances or heights. Supports both ultrametric and non-ultrametric trees.
-             * The scale bar includes major and minor ticks, and dynamically adjusts to the tree layout.
+             * Draws an interactive scale bar for phylogenetic tree visualizations with configurable ticks and labels.
+             * Supports both ultrametric (time-based) and non-ultrametric (divergence-based) trees with automatic tick spacing.
+             * Includes a draggable UI element with toggle control and dynamic label formatting.
              *
              * @function drawScale
-             * @param {d3.Selection} svg - SVG element where the scale bar will be drawn.
-             * @param {number} length - Length of the scale bar in pixels.
-             * @param {number} height - Vertical position of the scale bar from the top of the SVG in pixels.
-             * @param {number} max_length - Maximum length of the tree in the same units as the Newick file (e.g., number of alleles).
-             * @param {d3.HierarchyNode} root - A D3 hierarchy node, typically created using `d3.hierarchy(data)`. 
+             * @param {d3.Selection} svg - D3 selection of the SVG container where the scale will be rendered
+             * @param {number} length - Pixel length of the scale bar (visual width)
+             * @param {number} height - Vertical position from top of SVG (in pixels)
+             * @param {number} max_length - Maximum tree distance in data units (e.g., substitutions/site)
+             * @param {d3.HierarchyNode} root - D3 hierarchy node containing tree data with max_length property
              *   Should include a `data.max_length` field representing the starting cumulative distance from the root,
              *   which is used in non-ultrametric trees to adjust the scale bar labels.
              *
@@ -334,10 +334,11 @@
              * drawScale(svg, 200, 30, 1.2, treeRootNode);
              *
              * @remarks
-             * - Automatically appends a toggle switch UI to enable/disable the scale bar.
-             * - Minor ticks are drawn at 0.1 unit intervals by default.
-             * - Major ticks are drawn in red with corresponding numerical labels.
-             * - For ultrametric trees, the scale bar is rendered in reverse (right to left).
+             * - Creates a draggable scale bar via mouse and keyboard arrow keys group via CSS class 'scale-bar'
+             * - Implements smart tick spacing using human-friendly intervals (1, 2, 5, 10...)
+             * - Handles both forward (root→tips) and reverse (tips→root) scaling directions for two tree types
+             * - Minor ticks drawn at 1/10th intervals of major ticks
+             * - Major ticks colored red and have numeric labels up to the DECIMAL_PLACES defaulting to 1
              
              * @notes
              * scale bar is slightly difficult to add, as the svg viewport dat only shows up AFTER rendering
@@ -379,6 +380,7 @@
            let scale = `M 0 -${height} H ${length}` //defines the length of the scale object
            let stroke_width = 5
            let bar_opacity = 0.4
+           const fontSize = 12; // Match your label font-size
            
 
            scaleBarGroup.append("path")
@@ -389,47 +391,44 @@
             .attr("fill-opacity", 1)
             .attr("class", "scale-bar")
 
-            //let test_inc =  max_length / 10 // 10 was chosen randomly as I mock something up
-            let increase_factor = length / max_length
-            
-            let n_minor_divisions = 0, num_major_ticks = 0; 
-            //factors=[1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000]
-            factors=Array(10).fill(0).map((i,index)=>{return Math.pow(10,index)}); //generate array of factor from 1 to 1e10
-            factor_selected = 1; n_minor_divisions_step = 0.1;
-            //given a max length of the tree, understand the tree total length decimal point precision if it is less than 1.
-            //if less than zero find a factor that will covert it to integer space via multiplication (i.e for 0.53 multiply by 10 = 5.3)
-            //then identify the major and minor number of divisions valid for ultramertic trees
-            //from factors array find a scaling factor in the number space
-            for (var i=0; i<factors.length;i++){
-                //for decimal numbers
-                if(Math.trunc(max_length*factors[i]) > 0){
-                    num_major_ticks = Math.trunc(max_length*factors[i])
-                    n_minor_divisions = Math.round(max_length*factors[i]/n_minor_divisions_step) //using default step of 0.1
-                    factor_selected = factors[i]
-                    
-                    console.debug(length/num_major_ticks )
-                    // If only 1 major tick, try using the next higher factor
-                    if ( num_major_ticks === 1  && i + 1 < factors.length ) {
-                        factor_selected = factors[i + 1];
-                        num_major_ticks = Math.trunc(max_length * factor_selected);
-                        n_minor_divisions = Math.round(max_length * factor_selected / n_minor_divisions_step);
-                    }
-                    break
-    
-                }   
-               
+            // ===== CHANGE: Font Size to Average Width Mapping =====
+            // This table defines average character width multipliers for different font sizes in a typical sans-serif font (like Arial or Helvetica)
+            // E.g. Each character averages 0.62 × 12px = 7.44px wide
+            // We need to do approximate max label width calculation as DOM is not rendered at this stage preventing usage of bbox()
+            const FONT_METRICS = {
+                8:  0.52,  // avg width multiplier for 8px font
+                9:  0.55,
+                10: 0.58,
+                11: 0.60,
+                12: 0.62,  // default size
+                14: 0.65,
+                16: 0.68,
+                18: 0.70
+            };
+
+            /**
+             * Estimates the pixel width of text based on font size and average character width metrics.
+             * Uses predefined font metrics for accurate estimation without DOM measurement.
+             * 
+             * @function estimateTextWidth
+             * @param {string} text - The text string to measure
+             * @param {number} fontSize - Font size in pixels (must match FONT_METRICS keys for best accuracy)
+             * @returns {number} Estimated width in pixels
+             * 
+             **/
+            function estimateTextWidth(text, fontSize) {
+                const AVG_CHAR_WIDTH = FONT_METRICS[fontSize] || FONT_METRICS[12];
+                return text.length * AVG_CHAR_WIDTH * fontSize;
             }
-
-            console.debug("num_major_ticks=" + num_major_ticks +
-                ", minor_divisions=" + n_minor_divisions +
-                ", scale_bar=" + length + "px" +
-                ", factor_selected=" + factor_selected +
-                ", max_length=" + max_length +
-                ", length="+length+"px"+
-                ", num_major_ticks="+length/num_major_ticks+"px"
-                );
-
-            let minMajorTickSpacingPx = 20;              // Minimum spacing between major ticks in pixels
+            // Estimate maximum label width (using your font size 12px)
+            const maxLabel = max_length.toFixed(DECIMAL_PLACES);
+            const longestLabelWidth = estimateTextWidth(maxLabel, fontSize);
+            
+            
+            // Update min spacing to prevent label overlap (130% of longest label)
+            let minMajorTickSpacingPx = Math.max(longestLabelWidth, 25);// Minimum spacing between major ticks in pixels with 25 px as default min             
+            let n_minor_divisions = 0, num_major_ticks = 0; 
+            let factor_selected = 0;  
             let maxMajorTicks = Math.floor(length / minMajorTickSpacingPx);
 
             let niceSteps = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 25, 50, 100, 200, 500, 1000]; // "Nice" human-friendly steps
@@ -513,13 +512,10 @@
                 let major_ticks_coordinates_px = minor_ticks_coordinates_px.filter((c,index) => index % 10 === 0);
                 
                 for(let i=0; i <= full_steps; i+=1 ){
-                    //use minor divisions minor tick units and covert it to a major tick unit plus the root start distance
-                    const px = major_ticks_coordinates_px[i]; 
-                    //let d = Number(max_length/n_minor_divisions*10*i + distance_root_start).toFixed(DECIMAL_PLACES)
-                    //let d = (i * step + distance_root_start).toFixed(DECIMAL_PLACES);
-                    //let d = minor_step*i*pixel_per_unit.toFixed(DECIMAL_PLACES)
+                    const px = major_ticks_coordinates_px[i];
                     console.debug(distance_root_start)
-                    let d = (i * step + distance_root_start).toFixed(DECIMAL_PLACES);
+                    let raw_dist = i * step + distance_root_start; //some trees might start from non-zero distance at root
+                    let d = raw_dist === 0 ? "0" : raw_dist.toFixed(DECIMAL_PLACES);  //do not apply decimal points correction to 0
 
                     console.debug(distance_root_start + i * minor_step)
                     //major divisions
@@ -541,14 +537,15 @@
                     .attr("fill-opacity", 1)
                     .attr("dy", -height - 5)
                     .text( d )
-                    .attr("font-size", 14)
+                    .attr("font-size", fontSize)
                     .attr("class", "scale-bar")
                 }
             }else{
                 //the tree is ultrametric showing a distance bar from leaf to the root that is from right to left (<--)
                 let major_ticks_coordinates_px = minor_ticks_coordinates_px.reverse().filter((c,index) => index % 10 === 0);
                 for(let i=0; i <= full_steps; i+=1){
-                    let d = (i * step).toFixed(DECIMAL_PLACES);
+                    let raw_dist = i * step;
+                    let d = raw_dist === 0 ? "0" : raw_dist.toFixed(DECIMAL_PLACES); //do not apply decimal points correction to 0
                  
                     //add major ticks in RED
                     scaleBarGroup.append("path")
@@ -567,7 +564,7 @@
                     .attr("fill-opacity", 1)
                     .attr("dy", -height - 5)
                     .text( d )
-                    .attr("font-size", 14)
+                    .attr("font-size", fontSize)
                     .attr("class", "scale-bar")
                 }
 

--- a/html/table.html
+++ b/html/table.html
@@ -116,7 +116,7 @@
     <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
     <!-- Below switching to tidy tree 0.5.1 as the dev broke 0.5.0 -->
 
-    <script rel="stylesheet" type="text/javascript" href="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+    <!--script rel="stylesheet" type="text/javascript" href="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script-->
     
     <!--JQuery Beautiful Data Tables-->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
@@ -128,7 +128,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
     
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     
     
     <!--toggle buttons by https://palcarazm.github.io/bootstrap5-toggle/ -->
@@ -2045,7 +2045,7 @@
          *
          * @returns {Map<string, string>} A map of sample IDs to their concatenated metadata string.
          */
-         function extractAllMetadataJoined(selectedFields) {
+         /*function extractAllMetadataJoined(selectedFields) {
             const allDataMap = new Map();
             const tableElement = $('#metadata');
 
@@ -2061,9 +2061,10 @@
 
             const table = tableElement.DataTable();    
             // Get all data rows as an array of arrays or objects (depending on your config)
-            const allRowsData = table.rows({ search: 'applied' }).data(); 
+            const allRowsData = table.rows().data(); 
             // 'applied' gets filtered rows; use {} or 'none' for all rows (even filtered out)
             // Use table.rows().data() to get all rows regardless of filter
+            // Use table.rows({ search: 'applied' }).data() for filtered data
 
             // Iterate over each row
             allRowsData.each(row => {
@@ -2082,6 +2083,43 @@
             });
 
             return allDataMap;
+        }*/
+        function extractAllMetadataJoined(selectedFields) {
+            const MetaDataMap = new Map();
+
+            // Validate the global ORIGINAL_DATA
+            if (!ORIGINAL_DATA || !(ORIGINAL_DATA instanceof Map)) {
+                console.warn("ORIGINAL_DATA is not defined or not a Map.");
+                return MetaDataMap;
+            }
+
+            // Determine indexes of selected fields in the header
+            const selected_indexes = selectedFields.map(field => TABLE_HEADERS.indexOf(field));
+            if (selected_indexes.includes(-1)) {
+                console.warn("Some selected fields not found in TABLE_HEADERS.");
+            }
+            if (selected_indexes.length === 0) {
+                console.warn("No selected metadata field indexes specified.");
+                return MetaDataMap;
+            }
+
+            // Iterate through the full original data
+            for (const [sampleID, row] of ORIGINAL_DATA.entries()) {
+                if (!row || !Array.isArray(row)) {
+                    console.warn(`Invalid row for sampleID ${sampleID}`);
+                    continue;
+                }
+
+                // Get selected metadata fields
+                const selectedValues = selected_indexes.map(i => String(row[i] || "").trim());
+                const joinedFields = selectedValues.every(val => val === "") 
+                    ? sampleID 
+                    : selectedValues.join(" | ");
+
+                MetaDataMap.set(sampleID, joinedFields);
+            }
+
+            return MetaDataMap;
         }
 
         /**
@@ -2478,14 +2516,19 @@
                 return;
             }
 
+            const isEmpty = !MetaDataMap || MetaDataMap.size === 0;
+
             svg.selectAll("g.leaf-node").each(function () {
                 const g = d3.select(this);
                 const nodeId = this.id;
 
-                const joinedFields = MetaDataMap.get(nodeId);
-                const hasValue = typeof joinedFields === "string" && joinedFields.trim() !== "";
-                const newLabel = hasValue ? `${nodeId} | ${joinedFields.trim()}` : nodeId;
-
+                if (isEmpty) {
+                    newLabel = nodeId;
+                } else {
+                    const joinedFields = MetaDataMap.get(nodeId);
+                    const hasValue = typeof joinedFields === "string" && joinedFields.trim() !== "";
+                    newLabel = hasValue ? `${nodeId} | ${joinedFields.trim()}` : nodeId;
+                }
                 g.selectAll("text")
                     .filter(function () {
                         // Only update text elements that start with the nodeId
@@ -2555,6 +2598,7 @@
                     
                     // Extract all metadata already loaded as a map
                     const metadataJoinedMap = extractAllMetadataJoined(checkedFields);
+                    console.log(metadataJoinedMap.size)
         
                     // Append metadata to tree leaf nodes if available
                     if (metadataJoinedMap.size !== 0) {
@@ -2564,6 +2608,7 @@
 
                     }else{
                         console.warn("The metadata table map is empty.");
+                        updateLeafNodeLabels(metadataJoinedMap)
                     }
 
               
@@ -3510,8 +3555,8 @@
             <div class="row"> <!-- id="TreeSelections" style=""-->
                 <div id="control_panel" class="col-2 border border-primary px-1 overflow-auto">
                     <div id="tree_menu_buttons" class="row m-0">
-                                <div class="d-flex flex-row align-items-center p-0 text-left mt-1">
-                                    <button class="h-100 flex-grow-1 me-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
+                                <div class="d-flex flex-row align-items-stretch p-0 text-left mt-1 mb-1">
+                                    <button class="h-100 flex-grow-1 me-1 mb-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
                                         title="Select a newick file" onclick="document.getElementById('tree-selector').click();" name="newick" id="tree-upload-button">
                                         <i class="bi bi-upload me-1"></i>Newick <i class="bi bi-tree ml-1"></i>
                                     </button>
@@ -3524,8 +3569,8 @@
                                     <input type="file"  id="metadata-selector" 
                                     name="metadata-selector" accept=".tsv, .tab" hidden>
                                 </div>
-                                <button type="button" class="btn-sm btn-primary w-100 text-break mb-1 mt-1" data-toggle="tooltip" data-placement="top" 
-                                    title="Clear filters applied to the metadata table." name="ResetTable" id="reset-table-button">Clear filters</button>                                
+                                <!--button type="button" class="btn-sm btn-primary w-100 text-break mb-1 mt-1" data-toggle="tooltip" data-placement="top" 
+                                    title="Clear filters applied to the metadata table." name="ResetTable" id="reset-table-button">Clear filters</button-->                                
                                 
                                 <div class="d-flex flex-row align-items-center p-0 text-left">
                                     <button class="flex-grow-1 btn-sm btn-primary text-break me-1 mb-1" data-toggle="tooltip" data-placement="top"  
@@ -3626,20 +3671,65 @@
                                 </div>
 
                                 
-                                <div class="d-flex flex-row align-items-center p-0 text-left">
+                                <!--div class="d-flex flex-row align-items-center p-0 text-left">
                                     <button data-toggle="tooltip" data-placement="top" title="Filter metadata for selected nodes" 
                                     class="flex-grow-1 btn-sm btn-primary text-break w-100 h-100 mb-1 me-1" name="SearchMetadata" id="metadata-search-button">
                                     <i class="bi bi-search icon-image"></i> Filter data</button>
                                     <button data-toggle="tooltip" data-placement="top" title="Clear all selected nodes." 
                                     class="flex-grow-1  btn-sm btn-primary text-break w-100 h-100 mb-1" name="ClearSelectedNodes" 
                                     onclick="clear_selected_nodes()" id="clear-selected-nodes"><i class="bi bi-x-square"></i> Clear Nodes</button>
-                                </div>       
+                                </div-->     
+                                <div class="d-flex flex-row align-items-center p-0 text-left mt-1">
+                                    <!-- 1) Filter data -->
+                                    <button
+                                      id="metadata-search-button"
+                                      name="SearchMetadata"
+                                      class="flex-grow-1 btn-sm btn-primary text-break w-100 h-100 mb-1 me-1"
+                                      data-bs-toggle="tooltip"
+                                      data-bs-placement="top"
+                                      title="Filter metadata for selected nodes">
+                                      <i class="bi bi-search icon-image"></i>
+                                      Filter data
+                                    </button>
+                                  
+                                    <!-- 2) Clear filters (new) -->
+                                    <!--button type="button" class="btn-sm btn-primary w-100 text-break mb-1 mt-1" data-toggle="tooltip" data-placement="top" 
+                                    title="Clear filters applied to the metadata table." name="ResetTable" id="reset-table-button">Clear filters</button-->   
+                                    <button
+                                      id="reset-table-button"
+                                      name="ResetTable"
+                                      class="flex-grow-1 btn-sm btn-primary text-break w-100 h-100 mb-1 ms-1"
+                                      data-bs-toggle="tooltip"
+                                      data-bs-placement="top"
+                                      title="Clear filters applied to the metadata table."
+                                      onclick="resetMetadataFilters()">
+                                      <i class="bi bi-filter-circle"></i>
+                                      Clear filters
+                                    </button>
+                                  
+                                    <!-- 3) Clear selected nodes -->
+                                    <button
+                                      id="clear-selected-nodes"
+                                      name="ClearSelectedNodes"
+                                      class="flex-grow-1 btn-sm btn-primary text-break w-100 h-100 mb-1 ms-1"
+                                      data-bs-toggle="tooltip"
+                                      data-bs-placement="top"
+                                      title="Clear all selected nodes."
+                                      onclick="clear_selected_nodes()">
+                                      <i class="bi bi-x-square"></i>
+                                      Clear nodes
+                                    </button>
+                                  </div>  
                     </div> 
             
-                    <div data-toggle="tooltip" data-placement="top" title="Selected nodes on the tree will show up here." 
-                      class="col border border-primary p-1 w-100 Tree inline-block-child scrollbar-window" 
-                                id="SelectedNodes">
-                        <div class="d-flex h-100 text-center text-uppercase text-center"><small class="align-self-center w-100">Selected Nodes</small></div>        
+                    <div data-toggle="tooltip" data-placement="top" 
+                        title="Selected nodes on the tree will show up here." 
+                        style="max-height: 10vh;"
+                        class="col border border-primary p-1 w-100 Tree inline-block-child scrollbar-window" 
+                        id="SelectedNodes">
+                        <div class="d-flex h-100 text-center text-uppercase text-center">
+                            <small class="align-self-center w-100">Selected Nodes</small>
+                        </div>        
                     </div>
                 </div> 
 

--- a/html/table.html
+++ b/html/table.html
@@ -454,17 +454,7 @@
                 }
             }
 
-            console.debug("num_major_ticks=" + num_major_ticks +
-                ", n_minor_divisions=" + n_minor_divisions +
-                ", scale_bar=" + length + "px" +
-                ", factor_selected=" + factor_selected +
-                ", max_length=" + max_length +
-                ", length=" + length + "px" +
-                ", step="+step+
-                ", full_steps="+full_steps+
-                ", spacing_per_major=" + (length / num_major_ticks) + "px"
-            );
-
+            
             // Draw minor ticks going from left to right (-->) 
             let minor_ticks_coordinates_px = [];
             for (let i = 0; i <= n_minor_divisions; i++) {
@@ -513,11 +503,9 @@
                 
                 for(let i=0; i <= full_steps; i+=1 ){
                     const px = major_ticks_coordinates_px[i];
-                    console.debug(distance_root_start)
                     let raw_dist = i * step + distance_root_start; //some trees might start from non-zero distance at root
                     let d = raw_dist === 0 ? "0" : raw_dist.toFixed(DECIMAL_PLACES);  //do not apply decimal points correction to 0
 
-                    console.debug(distance_root_start + i * minor_step)
                     //major divisions
                     scaleBarGroup.append("path")
                     //.attr("d", `M ${i * increase_factor} -${height - stroke_width}  V -${height + stroke_width}`)
@@ -2237,8 +2225,6 @@
                 return false;
             }
             
-            console.log(document.querySelector('#TreeData').offsetHeight, 
-            document.querySelector('#control_panel').offsetHeight)
             let renderedTree = treeRendererFunction(tree_root); 
             //Match #TreeData height
             const treeDataHeight = document.querySelector('#TreeData').offsetHeight;
@@ -2246,27 +2232,9 @@
             treeData.style.height = `${treeDataHeight}px`;
             
             renderedTree.style.paddingLeft = renderedTree.style.paddingLeft + TREE_OFFSET;
-            console.log(document.querySelector('#TreeData').offsetHeight, 
-            document.querySelector('#control_panel').offsetHeight)
-            
             
             // Insert rendered svg tree into the DOM
             $("#TreeData").append(renderedTree);
-            console.log(document.querySelector('#TreeData').offsetHeight, 
-            document.querySelector('#control_panel').offsetHeight)
-
-            
-            
-
-            //const treeHeight = document.querySelector('#TreeData').offsetHeight;
-            //const menuHeight = document.querySelector('#tree_menu_buttons').offsetHeight;
-
-            //const availableHeight = treeHeight - menuHeight;
-            //console.log(availableHeight)
-
-            // Resize the side panel to match tree height
-            //console.log(`${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`)
-            //document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
             // Scroll to center horizontally
             document.querySelector('#TreeData').scrollTo(document.querySelector('#TreeData').scrollWidth/2,0)
         };
@@ -3677,23 +3645,66 @@
         document.querySelector('.dropdown-menu').style['position']="fixed"
     }
 
+    /**
+     * Enables dragging of the #colour-legend div by mouse.
+     * 
+     * When the user clicks and holds the mouse down on the legend div, 
+     * this function tracks mouse movements and moves the legend accordingly,
+     * preserving the initial grab offset within the div to prevent jumpiness.
+     * 
+     * It also accounts for the width of a left-side control panel (#control_panel)
+     * by offsetting the drag position, except when the document is in fullscreen mode,
+     * in which case the offset is ignored.
+     * 
+     * @param {MouseEvent} event - The initial mouse down event that starts dragging.
+     *                             It provides the starting coordinates of the drag.
+     * 
+     
+    * **/
     dragDivByMouse = function(event) {
-        let isDown = true;
-        let legend_div = document.querySelector('#colour-legend')
-        let control_panel_div = document.querySelector("#control_panel")
-        let TreeData_div = document.querySelector('#TreeData')
-        let offset = {"x": event.clientX - control_panel_div.offsetWidth, "y": event.clientY + TreeData_div.scrollTop}   
-        document.addEventListener('mouseup', function(){isDown = false}, true)
-        document.addEventListener('mousemove', move, true)
-        function move(event){
-            event.preventDefault();
-            if(isDown === true){
-                offset = {"x": event.clientX-control_panel_div.offsetWidth, "y": event.clientY + TreeData_div.scrollTop}
-                legend_div.style['left'] = offset.x+"px"
-                legend_div.style['top'] = offset.y+"px"
-            }    
+        const legend_div = document.querySelector('#colour-legend');
+        const control_panel_div = document.querySelector("#control_panel");
+
+        // Get bounding box of the legend
+        const rect = legend_div.getBoundingClientRect();
+
+        // Calculate initial grab offset (mouse position within the div)
+        const grabOffsetX = event.clientX - rect.left;
+        const grabOffsetY = event.clientY - rect.top;
+
+        // Store control panel width
+        let controlPanelOffset = control_panel_div.offsetWidth;
+        // Override offset if document is in fullscreen mode
+        if (document.fullscreen === true) {
+            controlPanelOffset = 0;
         }
-    }
+        
+        let isDown = true;
+
+        function move(e) {
+            if (!isDown) return;
+            e.preventDefault();
+
+            // Calculate new position, accounting for grab offset and control panel width
+            const newLeft = e.clientX - grabOffsetX - controlPanelOffset;
+            const newTop = e.clientY - grabOffsetY;
+
+            legend_div.style.left = newLeft + "px";
+            legend_div.style.top = newTop + "px";
+        }
+
+        function stopDrag() {
+            isDown = false;
+            document.removeEventListener('mousemove', move, true);
+            document.removeEventListener('mouseup', stopDrag, true);
+        }
+
+        // Attach listeners
+        document.addEventListener('mousemove', move, true);
+        document.addEventListener('mouseup', stopDrag, true);
+    };
+
+
 
     </script>
 </head>

--- a/html/table.html
+++ b/html/table.html
@@ -393,21 +393,23 @@
             let increase_factor = length / max_length
             
             let n_minor_divisions = 0, num_major_ticks = 0; 
-                factors=Array(10).fill(0).map((i,index)=>{return Math.pow(10,index)}); //generate array of factor from 1 to 1e10
-                factor_selected = 1; n_minor_divisions_step = 0.1;
-    
+            //factors=[1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000]
+            factors=Array(10).fill(0).map((i,index)=>{return Math.pow(10,index)}); //generate array of factor from 1 to 1e10
+            factor_selected = 1; n_minor_divisions_step = 0.1;
             //given a max length of the tree, understand the tree total length decimal point precision if it is less than 1.
             //if less than zero find a factor that will covert it to integer space via multiplication (i.e for 0.53 multiply by 10 = 5.3)
             //then identify the major and minor number of divisions valid for ultramertic trees
             //from factors array find a scaling factor in the number space
             for (var i=0; i<factors.length;i++){
+                //for decimal numbers
                 if(Math.trunc(max_length*factors[i]) > 0){
                     num_major_ticks = Math.trunc(max_length*factors[i])
                     n_minor_divisions = Math.round(max_length*factors[i]/n_minor_divisions_step) //using default step of 0.1
                     factor_selected = factors[i]
-
+                    
+                    console.debug(length/num_major_ticks )
                     // If only 1 major tick, try using the next higher factor
-                    if (num_major_ticks === 1 && i + 1 < factors.length) {
+                    if ( num_major_ticks === 1  && i + 1 < factors.length ) {
                         factor_selected = factors[i + 1];
                         num_major_ticks = Math.trunc(max_length * factor_selected);
                         n_minor_divisions = Math.round(max_length * factor_selected / n_minor_divisions_step);
@@ -417,21 +419,67 @@
                 }   
                
             }
-            
-            let test_inc_sub = length/n_minor_divisions //minor division size in tree scale units
-            let minor_ticks_coordinates_px = [];
-            
-            //draw minor scale ticks first going from left to right (-->) 
-            for(let i=0; i <=n_minor_divisions; i+=1){
-                scaleBarGroup.append("path")
-                .attr("d", `M ${i*test_inc_sub} -${height - stroke_width} V -${height}`)
-                .attr("fill-opacity", 1)
-                .attr("stroke", "#000")
-                .attr("class", "scale-bar")
-                .attr("stroke-width","1")
-                minor_ticks_coordinates_px.push(i*test_inc_sub)   
+
+            console.debug("num_major_ticks=" + num_major_ticks +
+                ", minor_divisions=" + n_minor_divisions +
+                ", scale_bar=" + length + "px" +
+                ", factor_selected=" + factor_selected +
+                ", max_length=" + max_length +
+                ", length="+length+"px"+
+                ", num_major_ticks="+length/num_major_ticks+"px"
+                );
+
+            let minMajorTickSpacingPx = 20;              // Minimum spacing between major ticks in pixels
+            let maxMajorTicks = Math.floor(length / minMajorTickSpacingPx);
+
+            let niceSteps = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 25, 50, 100, 200, 500, 1000]; // "Nice" human-friendly steps
+
+            let step = 1;
+            let full_steps = 0;
+            let remainder = 0;
+            let minor_per_step = 10;
+            let minor_step = 0.1;
+            let pixel_per_unit = length / max_length;
+            for (let i = 0; i < niceSteps.length; i++) {
+                let tickCount = Math.ceil(max_length / niceSteps[i]);
+                let tickSpacingPx = length / tickCount;
+                if (tickSpacingPx >= minMajorTickSpacingPx && tickCount <= maxMajorTicks) {
+                    step = niceSteps[i];
+                    minor_step = step / minor_per_step;
+                    full_steps = Math.floor(max_length / step);
+                    remainder = max_length - full_steps * step;
+                    num_major_ticks = full_steps + 1; // last tick will be at full_steps * step
+                    n_minor_divisions = full_steps * minor_per_step + Math.floor(remainder / minor_step);
+                    factor_selected = 1 / step;
+                    break;
+                }
             }
-            
+
+            console.debug("num_major_ticks=" + num_major_ticks +
+                ", n_minor_divisions=" + n_minor_divisions +
+                ", scale_bar=" + length + "px" +
+                ", factor_selected=" + factor_selected +
+                ", max_length=" + max_length +
+                ", length=" + length + "px" +
+                ", step="+step+
+                ", full_steps="+full_steps+
+                ", spacing_per_major=" + (length / num_major_ticks) + "px"
+            );
+
+            // Draw minor ticks going from left to right (-->) 
+            let minor_ticks_coordinates_px = [];
+            for (let i = 0; i <= n_minor_divisions; i++) {
+                let value = i * minor_step;
+                let px = value * pixel_per_unit;
+                scaleBarGroup.append("path")
+                    .attr("d", `M ${px} -${height - stroke_width} V -${height}`)
+                    .attr("fill-opacity", 1)
+                    .attr("stroke", "#000")
+                    .attr("class", "scale-bar")
+                    .attr("stroke-width", "1");
+                minor_ticks_coordinates_px.push(px);
+            }
+                        
             
             
             /**
@@ -459,13 +507,21 @@
              */
             
             if(!TREE_ULTRAMETRIC_P){
+                // From root to leaves (left to right)
                 //phylogenetic tree showing cumulative distance from root to the leaf (-->)
-                let distance_root_start = root.data.max_length //root node might start not at zero in ML phylo tree
+                let distance_root_start = root.data.max_length || 0 //root node might start not at zero in ML phylo tree
                 let major_ticks_coordinates_px = minor_ticks_coordinates_px.filter((c,index) => index % 10 === 0);
-                 
-                for(let i=0; i <= num_major_ticks; i+=1 ){
+                
+                for(let i=0; i <= full_steps; i+=1 ){
                     //use minor divisions minor tick units and covert it to a major tick unit plus the root start distance
-                    let d = Number(max_length/n_minor_divisions*10*i + distance_root_start).toFixed(DECIMAL_PLACES)
+                    const px = major_ticks_coordinates_px[i]; 
+                    //let d = Number(max_length/n_minor_divisions*10*i + distance_root_start).toFixed(DECIMAL_PLACES)
+                    //let d = (i * step + distance_root_start).toFixed(DECIMAL_PLACES);
+                    //let d = minor_step*i*pixel_per_unit.toFixed(DECIMAL_PLACES)
+                    console.debug(distance_root_start)
+                    let d = (i * step + distance_root_start).toFixed(DECIMAL_PLACES);
+
+                    console.debug(distance_root_start + i * minor_step)
                     //major divisions
                     scaleBarGroup.append("path")
                     //.attr("d", `M ${i * increase_factor} -${height - stroke_width}  V -${height + stroke_width}`)
@@ -491,7 +547,9 @@
             }else{
                 //the tree is ultrametric showing a distance bar from leaf to the root that is from right to left (<--)
                 let major_ticks_coordinates_px = minor_ticks_coordinates_px.reverse().filter((c,index) => index % 10 === 0);
-                for(let i=0; i <= num_major_ticks; i+=1){
+                for(let i=0; i <= full_steps; i+=1){
+                    let d = (i * step).toFixed(DECIMAL_PLACES);
+                 
                     //add major ticks in RED
                     scaleBarGroup.append("path")
                     .attr("d", `M ${major_ticks_coordinates_px[i]} -${height - stroke_width} V -${height + stroke_width}`)
@@ -508,7 +566,7 @@
                     .attr("stroke-width", 1)
                     .attr("fill-opacity", 1)
                     .attr("dy", -height - 5)
-                    .text( i/factor_selected )
+                    .text( d )
                     .attr("font-size", 14)
                     .attr("class", "scale-bar")
                 }
@@ -778,8 +836,6 @@
                     d.distance = (y0 += d.data.d) * k;
                     if (d.children) d.children.forEach(d => setDistance(d, y0, k));
                 }
-
-
 
                 // Rows are separated by dx pixels, columns by dy pixels. These names can be counter-intuitive
                 // (dx is a height, and dy a width). This because the tree must be viewed with the root at the

--- a/html/table.html
+++ b/html/table.html
@@ -586,7 +586,6 @@
 
 
                 function update(event, source) {
-                    console.log("590")
                     const duration = event?.altKey ? 2500 : 250; // hold the alt key to slow down the transition
                     const nodes = root.descendants().reverse(); // Might be able to replace with the recurse tree function for speed up
                     const links = root.links();
@@ -653,7 +652,7 @@
                                 });
                             }
                         });
-
+                    
                     nodeEnter.append("circle")
                         .attr("r", d => !d.data.leaf ? INNER_NODE_SIZE : LEAF_NODE_SIZE) // size 6 for leaf nodes and 4 for inner nodes
                         .attr("fill", d => !d.data.leaf ? "#555" : "#999")               
@@ -748,7 +747,8 @@
 
 
         const dendrogram_chart = (data) => {
-                // Made with lost of help from: https://observablehq.com/d/6c52fee38fb28b2f
+                
+                // Made with lots of help from: https://observablehq.com/d/6c52fee38fb28b2f
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
                 const width = parseInt(ele_style.width);
@@ -842,7 +842,7 @@
                     
                     svg.selectAll(".extension-node-links").remove();
                     
-
+                    
                     const linkExtension = svg.append("g") // Would probably save rendering if this was tied to the "entered nodes"
                             .attr("class", "extension-node-links")
                             .attr("fill", "none")
@@ -964,7 +964,7 @@
                         .attr("dy", 14)
                         .attr("font-size", 12);
 
-
+                       
                     nodeEnter.append("text")
                         // dx the 12 corresponds to a safety metric to add some space between nodes, no children, dx is 0 to align leaves to inner nodes
                         // Below two lines allow for inner nodes to show up
@@ -975,7 +975,10 @@
                         .attr("text-anchor", d => !d.data.leaf ? "end" : "start")
                         .style("visibility", d => d.data.leaf ? "" : SHOW_METADATA_IN_NAME ? "visible" : "hidden")
                         .attr("class", d => d.data.leaf ? "" : "inner-node-label")
-                        .text(d => d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name )
+                        .text(d => {
+                            // If meta is a string or name is defined for the node
+                            return d.data.meta ? d.data.name ? `${d.data.name}-${d.data.meta}` : d.data.meta : d.data.name
+                        })
                         .clone(true).lower()
                         .attr("stroke", "white");
                     
@@ -1167,7 +1170,6 @@
             
             
             function update(event, source){
-                console.log("1156")
 
                 const duration = event?.altKey ? 2500 : 250; // hold the alt key to slow down the transition
                 const nodes = root.descendants().reverse(); // Might be able to replace with the recurse tree function for speed up
@@ -1404,7 +1406,6 @@
                 
 
                 function update(event, source) {
-                    console.log("1394")
                     const duration = event?.altKey ? 2500 : 250; // hold the alt key to slow down the transition
                     const nodes = root.descendants().reverse();
                     const links = root.links();
@@ -1477,7 +1478,7 @@
                         .attr("r", d => d.data.leaf ? LEAF_NODE_SIZE : INNER_NODE_SIZE)
                         .attr("fill", d => d.data.leaf ? "#555" : "#999")
                         .attr("stroke-width", 10);
-
+        
                     nodeEnter.append("text") // TODO can do this with if statement and recurse over them all may be a bit slower but more mem friednly
                         .text((d) => {
                             if(!d.data.leaf || !TREE_ULTRAMETRIC_P){
@@ -1500,7 +1501,7 @@
                         .attr("dy", 18)
                         .attr("font-size", "12");
 
-
+                       
                     nodeEnter.append("text")
                         .attr("dy", d => !d.data.leaf ? -6 : 0) 
                         .attr("x", d => !d.data.leaf ? -6 : 6)
@@ -2017,8 +2018,8 @@
             $("#scale-bar-menu").remove()
             let chart_ = null;
             if(tree_root !== null){
-                
                 chart_ = TREE_SWITCH.get(TREE_VAL)(tree_root);
+                console.debug("Switching chart type via renderer function selected ", TREE_SWITCH.get(TREE_VAL).name);
                 chart_.style.paddingLeft = chart_.style.paddingLeft + TREE_OFFSET;
                 $("#TreeData").append(chart_);
                 $(".leaf-node").each((i, elm) => {
@@ -2033,7 +2034,80 @@
             }
         };
 
+        /**
+         * Extracts all metadata from the DataTables table with id "metadata" and returns a Map
+         * where each key is the sample ID (taken from the first column), and the value is a string
+         * concatenation of all the fields in that row separated by pipe (`|`) characters.
+         *
+         * This function accesses the full dataset managed by DataTables API, so it returns
+         * all rows regardless of pagination or filtering.
+         *
+         * Requires jQuery and DataTables library to be loaded.
+         *
+         * @returns {Map<string, string>} A map of sample IDs to their concatenated metadata string.
+         */
+         function extractAllMetadataJoined(selectedFields) {
+            const allDataMap = new Map();
+            const tableElement = $('#metadata');
+
+            const selected_indexes = selectedFields.map(item => TABLE_HEADERS.indexOf(item)); 
+            if (selected_indexes.length === 0){
+                console.warn("Empty selected metadata table indexes")
+            }   
+            // Check if table element exists and is initialized as a DataTable
+            if (!tableElement.length || !$.fn.DataTable.isDataTable(tableElement)) {
+                console.warn("DataTable '#metadata' not found or not initialized.");
+                return allDataMap;
+            }
+
+            const table = tableElement.DataTable();    
+            // Get all data rows as an array of arrays or objects (depending on your config)
+            const allRowsData = table.rows({ search: 'applied' }).data(); 
+            // 'applied' gets filtered rows; use {} or 'none' for all rows (even filtered out)
+            // Use table.rows().data() to get all rows regardless of filter
+
+            // Iterate over each row
+            allRowsData.each(row => {
+                // If row is an array (default), sampleID is row[0]
+                // If row is an object (if columns.data used), adjust accordingly
+
+                const sampleID = row[0].trim();
+                //all fields
+                //const joinedFields = row.slice(1).map(field => String(field).trim()).join('|');
+                 // Use only fields at the specified selected indexes (excluding the sampleID at index 0)
+                const selectedFields = selected_indexes.map(i => String(row[i]).trim());
+                const joinedFields = selectedFields.join(' | ');
+           
+
+                allDataMap.set(sampleID, joinedFields);
+            });
+
+            return allDataMap;
+        }
+
+        /**
+         * Annotate leaf nodes of the tree_root object with metadata from metadataMap.
+         * Assumes leaf nodes have `leaf === true`, match sampleID via `name`,
+         * and update the `meta` property.
+         *
+         * @param {Object} node - The root node of the tree (or subtree).
+         * @param {Map<string, string>} metadataMap - Map of sampleID (name) to metadata string.
+         * @returns {Object} The updated node (tree_root) with leaf nodes annotated.
+         */
+        function annotateLeafNodesWithMeta(node, metadataMap) {
         
+
+            if (node.leaf === true) {
+                const sampleID = node.name;
+                node.meta = metadataMap.has(sampleID) ? metadataMap.get(sampleID) : null;
+                return node;
+            }
+
+            if (node.children && node.children.length > 0) {
+                node.children = node.children.map(child => annotateLeafNodesWithMeta(child, metadataMap));
+            }
+            return node;
+        }
 
         let drawTree = (newick_) => {
             $("#tree-splash").remove()
@@ -2041,16 +2115,33 @@
             $("#tree-upload-button").remove()
             $("#scale-bar-menu").remove()
             let tree = kn_parse(newick_);
+            
             if(tree_root != null){
                 console.error("A tree is already drawn");
                 return false;
             }
-            tree_root = tree.root; // Save the trees root to redraw the tree when needed
-            let node_out = TREE_SWITCH.get(TREE_VAL)(tree_root)
-            node_out.style.paddingLeft = node_out.style.paddingLeft + TREE_OFFSET;
+            //Store the root for later access (used in updates, selections, etc.)
+            tree_root = tree.root; // Save the tree root to redraw the tree when needed
 
-            $("#TreeData").append(node_out);
+            
+
+            // Retrieve the rendering function from TREE_SWITCH based on current selection
+            // E.g. dendrogram_chart(), tidytree_chart(), dendrogram_circle(), cladeogram_chart()
+            const treeRendererFunction = TREE_SWITCH.get(TREE_VAL);
+            if (typeof treeRendererFunction !== "function") {
+                console.error("Invalid tree renderer function selected:", TREE_VAL);
+                return false;
+            }
+        
+            let renderedTree = treeRendererFunction(tree_root);      
+            renderedTree.style.paddingLeft = renderedTree.style.paddingLeft + TREE_OFFSET;
+            
+            // Insert rendered svg tree into the DOM
+            $("#TreeData").append(renderedTree);
+
+            // Resize the side panel to match tree height
             document.querySelector('#SelectedNodes').style.maxHeight = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
+            // Scroll to center horizontally
             document.querySelector('#TreeData').scrollTo(document.querySelector('#TreeData').scrollWidth/2,0)
         };
 
@@ -2080,61 +2171,61 @@
         
          
          
-         //html.innerHTML='<div class="paginate_button displayAll">DISPLAY ALL RECORDS</div>'
+                //html.innerHTML='<div class="paginate_button displayAll">DISPLAY ALL RECORDS</div>'
          
          
-        //let icon=document.create("i")
-        ///icon.style="position:absolute; top:0; right: 0; cursor: pointer; color:blue; margin-right:1px"
-        //icon.id="tree_fullscreen_btn"
-        //icon.onclick="tree_full_screen_mode()"
+                //let icon=document.create("i")
+                ///icon.style="position:absolute; top:0; right: 0; cursor: pointer; color:blue; margin-right:1px"
+                //icon.id="tree_fullscreen_btn"
+                //icon.onclick="tree_full_screen_mode()"
 
-        let html=document.createElement("div");
-        html.className = "paginate_button displayAll"
-        html.id = "paginate_button_all"
-        html.textContent = "ALL records"
-        if(document.querySelector("#paginate_button_all") === null){
-            document.querySelector("#metadata_paginate").appendChild(html)
-        }
-        let maximize_button_html=document.createElement("i");
-        maximize_button_html.style = "position:absolute; top:0; right: 0; cursor: pointer; color:blue; margin-right:1px"
-        maximize_button_html.className="d-flex fs-5 bi-arrow-up-right-square"
-        maximize_button_html.id = "metadata_fullscreen_btn"
-        maximize_button_html.setAttribute("onclick", "metadata_full_screen_mode()")
-        if(document.querySelector("#metadata_fullscreen_btn") === null){
-            document.querySelector("#metadata_wrapper").appendChild(maximize_button_html)
-        }    
-          
+                let html=document.createElement("div");
+                html.className = "paginate_button displayAll"
+                html.id = "paginate_button_all"
+                html.textContent = "ALL records"
+                if(document.querySelector("#paginate_button_all") === null){
+                    document.querySelector("#metadata_paginate").appendChild(html)
+                }
+                let maximize_button_html=document.createElement("i");
+                maximize_button_html.style = "position:absolute; top:0; right: 0; cursor: pointer; color:blue; margin-right:1px"
+                maximize_button_html.className="d-flex fs-5 bi-arrow-up-right-square"
+                maximize_button_html.id = "metadata_fullscreen_btn"
+                maximize_button_html.setAttribute("onclick", "metadata_full_screen_mode()")
+                if(document.querySelector("#metadata_fullscreen_btn") === null){
+                    document.querySelector("#metadata_wrapper").appendChild(maximize_button_html)
+                }    
+            
 
-         $('.paginate_button.displayAll:not(.disabled)', this.api().table().container())          
-         .on('click', function(){
+                $('.paginate_button.displayAll:not(.disabled)', this.api().table().container())          
+                .on('click', function(){
             
-            if(data_table.context[0]._iDisplayLength !== -1){
-                console.log("Paginate OFF")
+                    if(data_table.context[0]._iDisplayLength !== -1){
+                        console.log("Paginate OFF")
+                        
+                        data_table.context[0]._iDisplayLength=-1; //remove pagination
+                        data_table.draw();
+                        $('#metadata_length select').val(-1); //change "Show X entires" selector to ALL value
+                        
+                        $('#paginate_button_all').text("First 10")
+                        console.log(this.textContent)
+                        
+                    }else{
+                        console.log("Paginate ON")
+                        console.log($('#paginate_button_all').text())
+                        data_table.context[0]._iDisplayLength=10;
+                        $('#metadata_length select').val(10); //change "Show X entires" selector to ALL value
+                        //
+                        data_table.draw();
+                        $('#paginate_button_all').text("ALL records");
+                        console.log(this.textContent)
+                        
+                    }    
                 
-                //this.textContent="XXXXXX"
-                data_table.context[0]._iDisplayLength=-1; //remove pagination
-                data_table.draw();
-                $('#metadata_length select').val(-1); //change "Show X entires" selector to ALL value
-                
-                $('#paginate_button_all').text("First 10")
-                console.log(this.textContent)
-                
-            }else{
-                console.log("Paginate ON")
-                console.log($('#paginate_button_all').text())
-                data_table.context[0]._iDisplayLength=10;
-                $('#metadata_length select').val(10); //change "Show X entires" selector to ALL value
-                //
-                data_table.draw();
-                $('#paginate_button_all').text("ALL records");
-                console.log(this.textContent)
-                
-            }    
-            
-         });       
-   }
+                });       
+            }
 
             });
+
             $('#metadata_filter input').attr("id", "search-bar").attr("class", "table table-striped"); // Give search bar ID to squash warnings
 
             // TODO initializing table from json object would minimize copies
@@ -2151,7 +2242,21 @@
             }
         };
 
-
+        /**
+         * Creates and populates an HTML table with parsed metadata, then initializes a DataTable.
+         *
+         * This function removes existing UI elements related to loading and metadata selection,
+         * dynamically constructs the table header and body from the provided data and headers,
+         * injects the resulting HTML into the specified table element by table_id variable, 
+         * and then applies the
+         * DataTables jQuery plugin to enhance the table looks and add sorting, filtering, and pagination.
+         *
+         * @param {Array<Object>} parsed_data - Array of objects representing metadata rows.
+         *   Each object should contain properties corresponding to the headers.
+         * @param {string} table_id - jQuery selector string for the target table element (e.g., "#myTable").
+         * @param {Array<string>} table_headers - Array of strings specifying column headers and
+         * keys to access in each metadata object.
+         */
         let CreateTable = (parsed_data, table_id, table_headers) => {
             $("#table-splash").remove();
             $("#metadata-selector-input").remove();
@@ -2280,16 +2385,61 @@
         };
 
 
-
+        /**
+         * Initializes and updates UI properties of 'legend_dropdown_button' and 'metadata_fields_dropdown_button'  buttons.
+         *
+         * This function targets two specific dropdown buttons by their IDs:
+         * `#legend_dropdown_button` and `#metadata_fields_dropdown_button`.
+         * It sets appropriate button text, ensures they are marked as Bootstrap dropdown toggles,
+         * and updates the button style from `btn-danger` to `btn-primary` if applicable.
+         *
+         *
+         * Modifies:
+         * - Button text content
+         * - `data-bs-toggle` attribute so they are clickable
+         * - Bootstrap button classes (`btn-danger` to `btn-primary`)
+         *
+         * @function initialize_legend_menu
+         * @returns {void}
+         */
         let initialize_legend_menu = () => {
-            // update the legend text to reflect loading
-            let button = document.querySelector("#legend_dropdown_button");
-            button.textContent = "Colour tree by column";
-            button.dataset.bsToggle = "dropdown";
-            button.classList.remove("btn-danger");
-            button.classList.add("btn-primary");
-        }
+            console.log("initialize legend menu")
+            const buttonIds = ["#legend_dropdown_button", "#metadata_fields_dropdown_button"];
 
+            buttonIds.forEach(id => {
+                const button = document.querySelector(id);
+                if (!button) return;
+
+                // Update button text based on button ID
+                if (id === "#legend_dropdown_button") {
+                    button.textContent = "Colour tree by column";
+                } else if (id === "#metadata_fields_dropdown_button") {
+                    button.textContent = "Add metadata to nodes";
+                }
+
+                button.dataset.bsToggle = "dropdown";
+
+                // Replace btn-danger with btn-primary if exists
+                if (button.classList.contains("btn-danger")) {
+                    button.classList.remove("btn-danger");
+                    button.classList.add("btn-primary");
+                }
+
+            });
+        };
+
+        /**
+         * Initializes and renders the tree layout selection menu allowing to change layouts.
+         *
+         * This function updates the tree layout selection dropdown menu values.
+         * It generates a list of available tree layout options based on the keys
+         * of the global `TREE_SWITCH` map gloabal variable. Each tree layout option is rendered as a clickable
+         * dropdown item that, when selected, calls `switchTreeType(this)` with the
+         * chosen tree layout identifier.
+         *
+         * @function initialize_tree_menu
+         * @returns {void}
+         */
         let initialize_tree_menu = () => {
             let button = document.querySelector("#tree_dropdown_menu")
             button.textContent = "Select a tree layout"
@@ -2303,17 +2453,176 @@
 
         }
 
-        let create_legend_elements = (headers) => {
-                // Create html elements for the dropdown menu of itmes to creat the legend by
-                let text = new Array;
-                text.push('<div class=\"dropdown-menu\" id=\"legend-items\" style=\"overflow:visible;\">')
-                let header_offset = headers.slice(1);
-                header_offset.forEach((ele, idx) => {
-                    text.push(`\t<a onclick="colour_by_element(this)" class="dropdown-item" href="#" id="${idx+1}">${ele}</a>`)
-                });
-                text.push("</div>\n")
-                return text.join("\n")
+        /**
+         * Attaches event listeners to all metadata checkboxes in the 
+         * "Add metadata to nodes" dropdown menu. This function listens 
+         * for `change` events (i.e. when checkboxes are selected or deselected) 
+         * and logs the selected field and its checked status.
+         * **/
+        function initializeMetadataFieldListeners() {
+            console.log("initializeMetadataFieldListeners")
+            const container = document.querySelector('#dropdown_append_metadata2nodes');
+        
+            if (!container) {
+                console.warn("Dropdown container not found.");
+                return;
+            }
+
+            
+            // Select all items inside the dropdown menu based on label tag
+            const dropdownMenu = container.querySelector('.dropdown-menu');
+            
+            if (!dropdownMenu) {
+                console.warn("No .dropdown-menu found in metadata dropdown.");
+                return;
+            }
+            
+            const labels = dropdownMenu.querySelectorAll('label.dropdown-item');
+            if (labels.length === 0) {
+                console.warn("No label.dropdown-item elements found in .dropdown-menu.");
+                return;
+            }
+            labels.forEach(label => {
+                label.addEventListener('click', (event) => {
+                    const checkbox = label.querySelector('input[type="checkbox"]');
+                    if (!checkbox) return;
+                    
+                    // Only manually toggle if click was NOT directly on the checkbox area
+                    if (event.target !== checkbox) {
+                        if (checkbox.checked  === false) {
+                            checkbox.checked = true;
+                        }else{
+                            checkbox.checked = false;
+                    }
+                       
+                    }
+
+                    // Log checked and unchecked fields
+                    const allCheckboxes = dropdownMenu.querySelectorAll('input[type="checkbox"]');
+                    const checkedFields = [];
+                    const uncheckedFields = [];
+
+                    allCheckboxes.forEach(cb => {
+                        if (cb.checked) {
+                            checkedFields.push(cb.value);
+                        } else {
+                            uncheckedFields.push(cb.value);
+                        }
+                    });
+
+                    
+                    // Extract all metadata already loaded as a map
+                    const metadataJoined = extractAllMetadataJoined(checkedFields);
+
+                    console.log(checkedFields,TABLE_HEADERS, metadataJoined)
+        
+                    // Append metadata to tree leaf nodes if available
+                    if (metadataJoined.size !== 0) {
+                        tree_root = annotateLeafNodesWithMeta(tree_root, metadataJoined);
+                        redrawTree()
+                    }else{
+                        console.warn("The metadata table map is empty.");
+                    }
+
+              
+                }); //event
+            });
         }
+        
+
+
+        /**
+         * Dynamically creates and appends dropdown menu elements of the metadata fields
+         *
+         * This function handles rendering of dropdown menus for two different UI components:
+         * - A single-select legend dropdown (`#dropdown_legend`) where a user selects ONE metadata field to color tree nodes.
+         * - A multi-select metadata attachment dropdown (`#dropdown_append_metadata2nodes`) that allows users to check multiple metadata fields to annotate nodes.
+         *
+         * Each dropdown is rebuilt from scratch: any existing `.dropdown-menu` within the target container is removed and replaced
+         * with a newly generated one based on the `headers` array.
+         *
+         * @function create_legend_elements
+         * @param {string[]} headers - Array of metadata field names, with the first element typically being a sample ID (skipped).
+         *
+         * @example
+         * create_legend_elements(["SampleID", "Host", "Country", "Collection Date"]);
+         *
+         * Effects:
+         * - Clears and repopulates `.dropdown-menu` elements inside target containers.
+         * - Enables both single and multi-select interactions depending on the dropdown.
+         */
+
+        function create_legend_elements(headers) {
+            if (!headers || headers.length < 2) return;
+
+            const metadataFields = headers.slice(1); // skip sample ID
+
+            // Define target dropdowns and whether they should be multi-select
+            const dropdowns = [
+                { selector: '#dropdown_legend', multiSelect: false },
+                { selector: '#dropdown_append_metadata2nodes', multiSelect: true }
+            ];
+
+            dropdowns.forEach(({ selector, multiSelect }) => {
+                // Clear any existing dropdown-menu
+                const container = document.querySelector(selector);
+                if (!container) return;
+
+                // Remove old dropdown menu if exists
+                const oldMenu = container.querySelector('.dropdown-menu');
+                if (oldMenu) container.removeChild(oldMenu);
+
+                const button = container.querySelector('button');
+                const dropdown = document.createElement('div');
+                dropdown.className = 'dropdown-menu';
+                dropdown.style.overflow = 'visible';
+                //dropdown.style.maxHeight = '300px';
+                dropdown.style.overflow = 'auto';
+                dropdown.style.whiteSpace = 'nowrap';
+                dropdown.style.marginLeft = '4px';
+                dropdown.style.minWidth = `${button.offsetWidth + 8}px`;
+
+                
+
+                metadataFields.forEach((field, index) => {
+                    if (multiSelect) {
+                        // Multi-select item with checkbox "add metadta to nodes" button
+                        const label = document.createElement('label');
+                        label.className = 'dropdown-item d-flex align-items-center';
+                        label.style.cursor = 'pointer';
+
+                        const checkbox = document.createElement('input');
+                        checkbox.type = 'checkbox';
+                        checkbox.className = 'metadata-field-checkbox me-2';
+                        checkbox.id = `metadata-field-${index + 1}`;
+                        checkbox.value = field;
+
+                        label.appendChild(checkbox);
+                        label.appendChild(document.createTextNode(field));
+                        dropdown.appendChild(label);
+                        
+                    } else {
+                        // Single-select item with link
+                        const link = document.createElement('a');
+                        link.className = 'dropdown-item';
+                        link.href = '#';
+                        link.id = `legend-item-${index + 1}`;
+                        link.textContent = field;
+                        link.setAttribute('onclick', 'colour_by_element(this)');
+                        dropdown.appendChild(link);
+                    }
+                });
+
+                // Append new one
+                container.appendChild(dropdown);
+                
+                // Attach label listeners if this is the metadata multi-select dropdown
+                if (selector === '#dropdown_append_metadata2nodes' && multiSelect) {
+                    initializeMetadataFieldListeners();
+                }
+                });
+        }
+        
         
         let colour_by_element = (ele) => {
             // Create a legend for the column selected
@@ -2545,7 +2854,8 @@
                 CreateTable(METADATA, "#metadata", TABLE_HEADERS);
                 METADATA = null;
                 initialize_legend_menu();
-                $("#dropdown_legend").append(create_legend_elements(TABLE_HEADERS));
+                //$("#dropdown_legend").append(create_legend_elements(TABLE_HEADERS));
+                $("#dropdown_legend, #dropdown_append_metadata2nodes").append(create_legend_elements(TABLE_HEADERS));
             }
 
             $("#metadata-selector").change((event) => {
@@ -3265,10 +3575,16 @@
                                     <input onchange="show_inner_node_labels(this)" id="inner_node_labels_toggle" 
                                     type="checkbox" data-toggle="toggle" data-placement="top" title="Turn inner node labels on and off" data-onstyle="primary" data-size="sm">
                                 </div>  
-                                <div id="dropdown_legend" onclick="dropdownmenufix()" class="d-flex flex-wrap p-0 dropdown mb-1">
+                                <div id="dropdown_legend"  class="d-flex flex-wrap p-0 dropdown mb-1">
                                     <button id="legend_dropdown_button" class="btn btn-danger btn-sm dropdown-toggle w-100 text-wrap" type="button" data-toggle="tooltip" data-placement="top" title="List of fields to colour nodes by.">
                                         Awaiting metadata</button>
-                                </div> 
+                                </div>
+                                <div id="dropdown_append_metadata2nodes"  class="d-flex flex-wrap p-0 dropdown mb-1">
+                                    <button id="metadata_fields_dropdown_button" class="btn btn-danger btn-sm dropdown-toggle w-100 text-wrap" type="button" data-toggle="tooltip" data-placement="top" data-bs-auto-close="false" title="List of fields to colour nodes by.">
+                                        Add metadata to nodes</button>
+                                </div>
+
+                                
                                 <div class="d-flex flex-row align-items-center p-0 text-left">
                                     <button data-toggle="tooltip" data-placement="top" title="Filter metadata for selected nodes" 
                                     class="flex-grow-1 btn-sm btn-primary text-break w-100 h-100 mb-1 me-1" name="SearchMetadata" id="metadata-search-button">

--- a/html/table.html
+++ b/html/table.html
@@ -6,9 +6,15 @@
             display: inline-block;
         }
 
-        .row.no-wrap {
-            flex-wrap: nowrap;
+        #TreeData {
+            white-space: nowrap; /*prevents line wrapping inside*/
             overflow-x: auto;
+            box-sizing: border-box;
+        }
+
+
+        .row.no-wrap {
+            flex-wrap: nowrap; /*prevents the TreeData div with the svg tree to wrap around*/
         }
 
         .scrollbar-window{
@@ -518,7 +524,7 @@
                 SHOW_BRANCH_LENGTHS = false;
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
-                const width = parseInt(ele_style.width);
+                const width = parseInt(ele_style.width)-TREE_OFFSET;
     
                 //var width = window.innerWidth;
                 const marginTop = 40;
@@ -574,7 +580,7 @@
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
                     .attr("width", width) //makes sure all tree nodes are within view
-                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`)
+                    .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;`)
                 
                 svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}"); 
 
@@ -757,7 +763,7 @@
                 // Made with lots of help from: https://observablehq.com/d/6c52fee38fb28b2f
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
-                const width = parseInt(ele_style.width);
+                const width = parseInt(ele_style.width)-TREE_OFFSET;
                 //var width = window.innerWidth;
                 const marginTop = 40;
                 const marginRight = 10;
@@ -806,8 +812,8 @@
                 // Create the SVG container, a layer for the links and a layer for the nodes.
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
-                    .attr("width", width + 20) //makes sure all tree nodes are within view
-                    .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`) 
+                    .attr("width", width) //makes sure all tree nodes are within view
+                    .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;`) 
 
                 svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");    
                 
@@ -1064,7 +1070,7 @@
             var ele = document.getElementById("TreeData");
             var ele_style = window.getComputedStyle(ele);
             
-            const width = parseInt(ele_style.width);
+            const width = parseInt(ele_style.width)-TREE_OFFSET;
             const height = width;
             const outerRadius = width / 2; 
             const innerRadius = outerRadius - 170;
@@ -1124,7 +1130,7 @@
                 .attr("viewBox", [0, 0, width, height])
                 .attr("font-family", "sans-serif")
                 .attr("font-size", 10)
-                .attr("style", `width:100%; height: auto; font: 10px sans-serif; user-select: auto;`);
+                .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;`);
             
             svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");  
 
@@ -1367,7 +1373,7 @@
                 SHOW_BRANCH_LENGTHS = false;
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
-                const width = parseInt(ele_style.width);
+                const width = parseInt(ele_style.width)-TREE_OFFSET;
     
 
                 
@@ -1394,7 +1400,7 @@
                     .attr("id", "TreeSVG")
                     .attr("width", width + 20) //makes sure all tree nodes are within view
                     .attr("height", dx)
-                    .attr("style", `width:${width}px; height: auto; font: 10px sans-serif; user-select: auto;`)
+                    .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;`)
 
                 
                 svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");   
@@ -2555,20 +2561,30 @@
          * updateLeafNodeLabels(MetaDataMap);
          */
          function updateLeafNodeLabels(MetaDataMap) {
-            const svg = d3.select("#TreeSVG");
+
+            const svg = d3.select("#TreeSVG")
+            const treeContainer = svg.select('g[cursor="pointer"][pointer-events="all"]')
+            const svgAttrWidth = svg.attr("width")
+            
+            if (treeContainer.empty()) {
+                console.warn("Main tree container group not found.");
+                return;
+            }
+
+            console.debug(`Before change tree width ${treeContainer.node().getBBox().width} and svg declared ${svg.attr("width")}`)
             if (svg.empty()) {
                 console.warn("Tree SVG not found.");
                 return;
             }
 
+            //update leaf nodes update labels
             const isEmpty = !MetaDataMap || MetaDataMap.size === 0;
-
             svg.selectAll("g.leaf-node").each(function () {
                 const g = d3.select(this);
                 const nodeId = this.id;
 
                 if (isEmpty) {
-                    newLabel = nodeId;
+                    newLabel = `${nodeId} | NA`;
                 } else {
                     const joinedFields = MetaDataMap.get(nodeId);
                     const hasValue = typeof joinedFields === "string" && joinedFields.trim() !== "";
@@ -2581,11 +2597,17 @@
                     })
                     .text(newLabel);
             });
+
             
+            const newWidth = treeContainer.node().getBBox().width
+            console.debug(`Final calculated tree width after node update ${newWidth}`)
+
+            // Parse the existing viewBox
+            const viewBoxAttr = svg.attr("viewBox")
+            const [minX, minY, width, height] = viewBoxAttr.split(/[\s,]+/).map(Number)
+            // Update the width of the svg element
+            svg.attr("width", newWidth).attr("viewBox", `${minX} ${minY} ${newWidth} ${height}`)
         }
-
-
-       
 
         /**
          * Attaches event listeners to all metadata checkboxes in the 
@@ -3496,9 +3518,10 @@
 
 
         // Call once DOM is ready
+        /*
         document.addEventListener("DOMContentLoaded", () => {
             initializeClusterInfoToggleBehavior();
-        });
+        });*/
 
 
         clear_selected_nodes = function(){
@@ -3624,7 +3647,7 @@
     <body>
         <div class="container-fluid m-0">
             <div class="row no-wrap"> <!-- id="TreeSelections" style=""-->
-                <div id="control_panel" class="col-2 border border-primary px-1 overflow-auto">
+                <div id="control_panel" class="col-2 border border-primary px-1 overflow-visible position-relative">
                     <div id="tree_menu_buttons" class="row m-0">
                                 <div class="d-flex flex-row align-items-stretch p-0 text-left mt-1 mb-1">
                                     <button class="h-100 flex-grow-1 me-1 mb-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
@@ -3658,18 +3681,18 @@
                                     </button>
                                 </div>
                                 <div class="dropdown p-0">
-                                    <button class="w-100 flex-grow-1 mb-1 btn-sm btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                        <i class="bi bi-download me-1"></i> Export Meta Table
+                                    <button class="w-100 flex-grow-1 mb-1 btn-sm btn-primary dropdown-toggle text-wrap" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                        <i class="bi bi-download me-1"></i>Export Meta Table
                                     </button>
                                     <ul class="dropdown-menu">
                                         <li><a id="export-metadata-view" data-toggle="tooltip" data-placement="top" title="Export the currently selected metadata." 
-                                        class="dropdown-item flex-grow-1 me-1 btn-sm btn-primary text-break mb-1" onclick="export_metadata_table(this)" id="export-metadata-view">
-                                            <i class="bi bi-download me-1"></i> Export Filtered Table
+                                        class="dropdown-item text-wrap flex-grow-1 me-1 btn-sm btn-primary text-break mb-1" onclick="export_metadata_table(this)" id="export-metadata-view">
+                                            <i class="bi bi-download me-1"></i>Export Filtered Table
                                             </a>
                                         </li>
                                         <li><a id="export-metadata-table" data-toggle="tooltip" data-placement="top" title="Export the currently selected metadata." 
-                                            class="dropdown-item flex-grow-1 me-1 btn-sm btn-primary text-break mb-1" onclick="export_metadata_table(this)" id="export-metadata-view">
-                                                <i class="bi bi-download me-1"></i> Export Full Table
+                                            class="dropdown-item text-wrap flex-grow-1 me-1 btn-sm btn-primary text-break mb-1" onclick="export_metadata_table(this)" id="export-metadata-view">
+                                                <i class="bi bi-download me-1"></i>Export Full Table
                                             </a>
                                         </li>
                                     </ul>
@@ -3737,7 +3760,8 @@
                                         Awaiting metadata</button>
                                 </div>
                                 <div id="dropdown_append_metadata2nodes"  class="d-flex flex-wrap p-0 dropdown mb-1">
-                                    <button id="metadata_fields_dropdown_button" class="btn btn-danger btn-sm dropdown-toggle w-100 text-wrap" type="button" data-toggle="tooltip" data-placement="top" data-bs-auto-close="false" title="List of fields to colour nodes by.">
+                                    <button id="metadata_fields_dropdown_button" class="btn btn-danger btn-sm dropdown-toggle w-100 text-wrap" type="button" data-toggle="tooltip" 
+                                    data-placement="top" data-bs-auto-close="false" title="List of fields to colour nodes by">
                                         Add metadata to nodes</button>
                                 </div>
 
@@ -3808,7 +3832,7 @@
                 onscroll="scroll_legend_into_view(document.querySelector('#colour-legend'), document.querySelector('#tree_fullscreen_btn'), this)"
                 id="TreeData">
 
-                        <div id="tree-splash" class="fs-2 d-flex justify-content-center align-items-center" style="height:50vh;"><i class="bi bi-tree"></i> Your tree will show up here when loaded!</div>
+                        <div id="tree-splash" class="w-100 h-100 fs-2 d-flex justify-content-center align-items-center" style="height:50vh;"><i class="bi bi-tree"></i> Your tree will show up here when loaded!</div>
                         
                         <div id="colour-legend"
                         class="d-none p-1 position-absolute border border-primary text-break Tree inline-block-child scrollbar-window" 
@@ -3820,30 +3844,27 @@
                         
                 </div> 
 
-                </div>
-                
-                
             </div>
-            <div class="row" style="height:5px;background-color: #0d6efd;">
-                <a  href="#" data-bs-toggle="collapse" 
-                data-bs-target="#ClusterInfo">
-                </a>
+                
+                
+        </div>
+        
+        <div class="row m-0" style="height:5px;background-color: #0d6efd;">
+                <a  href="#" data-bs-toggle="collapse" data-bs-target="#ClusterInfo"></a>
                 <div class="p-0" onmousedown="vertical_div_resize(event)" 
-                style="position:absolute; cursor: ns-resize; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); border-radius: 3px; left:50%; 
-                background-color: #dc3545; width:50px; height:10px; z-index: 2;">
+                    style="position:absolute; cursor: ns-resize; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); border-radius: 3px; left:50%; 
+                    background-color: #dc3545; width:50px; height:10px; z-index: 2;">
                 </div>
-            </div>
-            <div id="ClusterInfo" class="row bg-white collapse show border border-primary w-100 m-0">
+        </div>
+        
+        <div id="ClusterInfo" class="row bg-white collapse show border border-primary w-100 m-0">
                 <div class="col-12 p-0 overflow-auto" style="height:28.9vh">
                     <div id="table-splash" class="fs-2 d-flex justify-content-center align-items-center" style="height:25vh" ><i class="bi bi-file-spreadsheet"></i> Your metadata will go here when loaded!</div>
                     <table id="metadata" class="w-100 display overflow-scroll" >
                     </table>
-                </div>    
-            </div>
-                
-                <!-- Need to have the legend be scrollable and situated under the selected nodes-->
-                
-            
+                    </div>    
+                </div>            
+                <!-- Need to have the legend be scrollable and situated under the selected nodes-->  
         </div> 
         <div id="TestSubTree"></div> 
         


### PR DESCRIPTION
This update introduces several usability and visualization enhancements over [v0.1.0](https://github.com/phac-nml/ArborView/tree/v0.1.0)

## New features
### Scale Bar Enhancements
- Dynamically adjusts tick steps, spacing, and tick labels based on tree length.
- Accurate tick label positioning even for trees not starting at zero.
- Improved visual consistency across different tree sizes and resolutions.

### Node Annotation Support by Metadata Fields
- Nodes can now be annotated directly from the metadata.
- Annotations are integrated into the visualization with customizable display.
- Enables clearer interpretation of node attributes (e.g., confidence values, taxonomic tags, etc.).


## Improvements
Stable drag-and-drop behaviour for legend (#colour-legend) including:
- Offset-corrected mouse drag (no more jump on mousedown).
- Fullscreen-aware positioning logic.

