### PR TITLE
added overflow visible tree svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,22 @@
 # ArborView: Changelog
 
-
 ## Unreleased
 
 ### `Changed`
+
 - Made the scale bar draggable and keyboard-movable for dendrogram layouts. Introduced support for ultrametric trees  v [PR 14](https://github.com/phac-nml/ArborView/pull/14)
 - Added an alternative distance display for ultrametric and ML trees. [PR 13](https://github.com/phac-nml/ArborView/pull/13)
 - Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
 - Changed the `IDs` button hoverover tip message to reflect the new copy leaf node identifiers to the clipboard functionality [PR 11](https://github.com/phac-nml/ArborView/pull/11)
 - Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
 - Text selection cursor symbol changes from hand to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. [PR 8](https://github.com/phac-nml/ArborView/pull/8)
+- TreeSVG overflow is now visible preventing cutoff labels. [PR 18](https://github.com/phac-nml/ArborView/pull/18)
   
 ### `Added`
-- Added duplicated `<text>` tags removal during SVG image export from the tree leaf nodes for accurate keyword searches on an resulting SVG image [PR 10] (https://github.com/phac-nml/ArborView/pull/10) 
+
+- Added duplicated `<text>` tags removal during SVG image export from the tree leaf nodes for accurate keyword searches on an resulting SVG image [PR 10] (<https://github.com/phac-nml/ArborView/pull/10>)
 - Added text selection of tree text including distance values and leaf nodes text in both webapp and SVG image exports [PR 8](https://github.com/phac-nml/ArborView/pull/8)
 - Metadata fields have been added to inner and outer node labels. [PR 4](https://github.com/phac-nml/ArborView/pull/3)
 - Cladeogram tree layout. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
 - Added slider for adjusting line thickness. [PR 5](https://github.com/phac-nml/ArborView/pull/5)
 - Added copy tree nodes to the clipboard [PR 11](https://github.com/phac-nml/ArborView/pull/11)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Changed the `IDs` button hoverover tip message to reflect the new copy leaf node identifiers to the clipboard functionality [PR 11](https://github.com/phac-nml/ArborView/pull/11)
 - Tree layout selection is now a drop down menu and not a slider. [PR 2](https://github.com/phac-nml/ArborView/pull/2)
 - Text selection cursor symbol changes from hand to a pipe symbol (`|`) when mouse over the text in both the webapp tree and SVG exported image. [PR 8](https://github.com/phac-nml/ArborView/pull/8)
-- TreeSVG overflow is now visible preventing cutoff labels. [PR 18](https://github.com/phac-nml/ArborView/pull/18)
+- TreeSVG overflow is now visible preventing cutoff labels, fixing ENHC0010243 [PR 18](https://github.com/phac-nml/ArborView/pull/18)
   
 ### `Added`
 

--- a/html/table.html
+++ b/html/table.html
@@ -1037,7 +1037,7 @@
                     nodeEnter.append("text")
                         .text((d) => {
                                 if(!d.data.leaf || !TREE_ULTRAMETRIC_P){
-                                    return Number((d.display_dist).toFixed(DECIMAL_PLACES))
+                                    return Number((d.display_dist).toFixed(DECIMAL_PLACES));
                                 }
                             })
                         .attr("class", "branch-length")

--- a/html/table.html
+++ b/html/table.html
@@ -893,7 +893,7 @@
                 const svg = d3.create("svg")
                     .attr("id", "TreeSVG")
                     .attr("width", width) //makes sure all tree nodes are within view
-                    .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;`) 
+                    .attr("style", `height: auto; font: 10px sans-serif; user-select: auto;overflow: visible;`) 
 
                 svg.append("defs").append("style").attr("type", "text/css").text("svg text {cursor: text}");    
                 


### PR DESCRIPTION
Fixed issue with tree labels being cut off on SVG, due to overflow not being visible. Fixing `ENHC0010243`

Defect Comment:
Description: Currently, the left most inner node distance labels may be cutoff in the rendered arborview tree. This is visually unappealing and most importantly does not show the actual distances that should be displayed on the tree. Removing all decimals still leaves some distances unreadable.