### PR TITLE
Fix/blank metadata consistency across app elements PLUS other other minor fixes on Zoom and Legend

### DIFF
--- a/html/table.html
+++ b/html/table.html
@@ -3696,7 +3696,8 @@
         }    
 
         let select_deselect_nodes_by_field_value = (legend_node, column_index) => {
-            
+            const categoryName = legend_node.getAttribute('data-fieldvalue');
+            const columnName = data_table.column(column_index).header().innerText.trim(); 
             //find indices of filtered data in a metadata table
             let getIndexes = () => {
                 return data_table.rows((idx, data, node) => {
@@ -3709,26 +3710,39 @@
             
             let selected = legend_node.classList.contains('fw-bold') ? true : false
             
+            
+
+            let selected_node_ids = data_table.cells(indexes,0).data();
+
+            if (selected_node_ids.length === 0) {
+               
+                Swal.fire({
+                    title: "Selected Nodes Not Found in Metadata",
+                    html: `The selected category <b>${categoryName}</b> in in column <b>${columnName}</b> contains samples are currently hidden.<br><br>Would you like to clear ALL metadata filters to select these nodes?`,
+                    icon: "warning",
+                    showCancelButton: true,
+                    confirmButtonColor: "#3085d6",
+                    cancelButtonColor: "#d33",
+                    confirmButtonText: "Yes, clear filters"
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        data_table.clear();
+                        data_table.rows.add(Array.from(ORIGINAL_DATA.values())).draw();
+                        $("td").addClass("editable");
+                        $("td:not(:first-child)").attr("contenteditable", true);
+                        
+                        select_deselect_nodes_by_field_value(legend_node, column_index);
+                    }
+                });
+                return; 
+            }
+
             if(!selected){
                 legend_node.classList.add('fw-bold');
             }else{
                 legend_node.classList.remove('fw-bold');
             }
-
-            let selected_node_ids = data_table.cells(indexes,0).data();
-
-            // Reset metadata by removing filters if no IDs were found (metadata is likely filtered)
-            if (selected_node_ids.length === 0) {
-                data_table.clear();
-                data_table.rows.add(Array.from(ORIGINAL_DATA.values())).draw();
-                $("td").addClass("editable");
-                $("td:not(:first-child)").attr("contenteditable", true);
                 
-                // Refresh indices after reset
-                indexes = getIndexes();
-                selected_node_ids = data_table.cells(indexes, 0).data();
-            }
-            
 
             for(var i = 0; i < selected_node_ids.length; i++) {
                 let tree_node = document.querySelector( `[id='${selected_node_ids[i]}']`)

--- a/html/table.html
+++ b/html/table.html
@@ -223,6 +223,7 @@
         const DATA = __DEADFOOD__;
         const DEBUG = false;
         const TREE_OFFSET = 100;
+        const TREE_LEFT_MARGIN_VIEWBOX_OFFSET = 30; //Space to accommodate near the root inner node labels
         var METDATA_TABLE_NON_FULL_SCREEEN_HEIGTH = null; //before changing to full screen mode save the current size of the metadata table
         var NEWICK = null;
         var tree_root = null;
@@ -628,7 +629,7 @@
                 SHOW_BRANCH_LENGTHS = false;
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
-                const width = parseInt(ele_style.width)-TREE_OFFSET;
+                const width = parseInt(ele_style.width)-TREE_OFFSET+TREE_LEFT_MARGIN_VIEWBOX_OFFSET;
     
                 //var width = window.innerWidth;
                 const marginTop = 40;
@@ -722,7 +723,8 @@
                     const transition = svg.transition("tree-layout")
                         .duration(duration)
                         .attr("height", height)
-                        .attr("viewBox", [0, left.x - marginTop, width, height])
+                        .attr("viewBox", [-TREE_LEFT_MARGIN_VIEWBOX_OFFSET, left.x - marginTop, 
+                                            width, height])
                         .tween("resize", window.ResizeObserver ? null : () => () => svg.dispatch("toggle"))
                         .on("end", () => {
                             svg.dispatch("layout-complete");// This tells the rest of the app "The tree is done rendering!"
@@ -880,7 +882,7 @@
                 // Made with lots of help from: https://observablehq.com/d/6c52fee38fb28b2f
                 var ele = document.getElementById("TreeData");
                 var ele_style = window.getComputedStyle(ele);
-                const width = parseInt(ele_style.width)-TREE_OFFSET;
+                const width = parseInt(ele_style.width)-TREE_OFFSET+TREE_LEFT_MARGIN_VIEWBOX_OFFSET;
                 const marginTop = 40;
                 const marginRight = 10;
                 const marginBottom = 30; // updated for viewing
@@ -1007,7 +1009,8 @@
                     const transition = svg.transition("tree-layout")
                         .duration(duration)
                         .attr("height", height)
-                        .attr("viewBox", [0, left.x - marginTop, width, height])
+                        .attr("viewBox", [-TREE_LEFT_MARGIN_VIEWBOX_OFFSET, left.x - marginTop, 
+                                            width, height])
                         .tween("resize", window.ResizeObserver ? null : () => () => svg.dispatch("toggle"))
                         .on("end", () => {
                             svg.dispatch("layout-complete");// This tells the rest of the app "The tree is done rendering!"
@@ -3441,14 +3444,27 @@
 
         });
 
+
+        
         zoom_tree = function(){
             
             const zoom_times = parseFloat(document.querySelector('#zoom_slider').value)
             const tree_data_elm = document.querySelector('#TreeData')
             const tree_svg = document.querySelector('#TreeSVG')
             document.querySelector('#zoom_slider_value').textContent =  zoom_times 
-            const new_width = ORIGINAL_WIDTH_SVG  * zoom_times //use global value as getBBox() at high zooms gives wrong values
-            const prev_width = parseFloat(document.querySelector('#TreeSVG').style.width)
+
+            // Define the base coordinate width (unzoomed) including your offset
+            const base_coordinate_width = ORIGINAL_WIDTH_SVG + TREE_LEFT_MARGIN_VIEWBOX_OFFSET + 20;
+            const current_vb = tree_svg.viewBox.baseVal; //current viewBox values
+            const base_coordinate_height = current_vb.height; //the unzoomed height of the tree.
+
+            //Calculate new physical dimensions of width and height as both must be scaled for zoom to work
+            const new_width = base_coordinate_width * zoom_times 
+            const new_height = base_coordinate_height * zoom_times
+
+            //Get the previous physical width before zooming
+            const prev_width = parseFloat(document.querySelector('#TreeSVG').style.width) || base_coordinate_width;
+            const prev_height = parseFloat(document.querySelector('#TreeSVG').style.height) || base_coordinate_height;
 
             //Previous x and y scroll positions before applying a zoom
             const prev_x_scroll_pos = tree_data_elm.scrollLeft
@@ -3457,31 +3473,27 @@
             //document.querySelector('#TreeSVG').style.width = new_width ; //modify width of SVG tree
             // svg width was not being properly set on firfox
             document.querySelector('#TreeSVG').setAttribute("width", `${new_width}`); //modify width of SVG tree
+            document.querySelector('#TreeSVG').setAttribute("height", `${new_height}`); //modify height of SVG tree
 
-            //store new translated x and y coordinates after zooming 
-            let zoom_x_translated = 0 
-            let zoom_y_translated = 0
-            const scaleChange = new_width/prev_width //sometimes the specified zoom factor is not exact, use this value instead
-            
-            //keeping zoom centered on an element
-            if(new_width > prev_width){
-                //get previous scroll position which is the left most x-coordinate position of a view
-                //translate that coordiante to a new zoomed state
-                //add 1/4 view field length scaled to a new zoomed state coordinate
-                zoom_x_translated =  prev_x_scroll_pos*scaleChange + (tree_data_elm.clientWidth/4)*(scaleChange)
-                zoom_y_translated =  prev_y_scroll_pos*scaleChange + (tree_data_elm.clientHeight/4)*(scaleChange)
-            
-            }else{
-                //Zooming out 
-                //Scale current scroll position (previous scroll + 1/4 view field distance) to a new coordinate zoomed out state
-                //Substract the 1/4 offeset/margin that is already in the needed zoomed out state (no adjustments)
-                zoom_x_translated =  prev_x_scroll_pos*scaleChange - (tree_data_elm.clientWidth/4)
-                zoom_y_translated =  prev_y_scroll_pos*scaleChange - (tree_data_elm.clientHeight/4)
-            
-            }
-            document.querySelector('#TreeData').scrollTo(zoom_x_translated,zoom_y_translated)
+            // This is what makes the tree actually look bigger inside the new width/height
+            tree_svg.setAttribute("viewBox", `${-TREE_LEFT_MARGIN_VIEWBOX_OFFSET} ${current_vb.y} ${base_coordinate_width} ${base_coordinate_height}`);
+
+
+            // Calculate the scale change factor for width and height
+            const scaleChangeX = new_width / prev_width;
+            const scaleChangeY = new_height / prev_height; 
+
+            // Focus on the center of the current view for a smoother experience
+            // Formula: (Current center point * scale) - half of the window
+            const view_w = tree_data_elm.clientWidth;
+            const view_h = tree_data_elm.clientHeight;
+
+            let zoom_x_translated = (prev_x_scroll_pos + view_w / 2) * scaleChangeX - (view_w / 2);
+            let zoom_y_translated = (prev_y_scroll_pos + view_h / 2) * scaleChangeY - (view_h / 2);
+            document.querySelector('#TreeData').scrollTo(zoom_x_translated, zoom_y_translated);
+
         }
-
+        
         scroll_into_view_treenode = function(id){
             let selectedNode = document.querySelector(`[id='${id}']`)
             if(selectedNode !== null){

--- a/html/table.html
+++ b/html/table.html
@@ -3488,9 +3488,21 @@
             const view_w = tree_data_elm.clientWidth;
             const view_h = tree_data_elm.clientHeight;
 
-            let zoom_x_translated = (prev_x_scroll_pos + view_w / 2) * scaleChangeX - (view_w / 2);
-            let zoom_y_translated = (prev_y_scroll_pos + view_h / 2) * scaleChangeY - (view_h / 2);
+            // Calculate the physical "Boundaries" of the new scaled content.
+            const maxPossibleX = new_width - view_w;
+            const maxPossibleY = new_height - view_h;
+
+            // Calculate the "Ideal" scroll target.
+            let targetX = (prev_x_scroll_pos + view_w / 2) * scaleChangeX - (view_w / 2);
+            let targetY = (prev_y_scroll_pos + view_h / 2) * scaleChangeY - (view_h / 2);
+
+            // This prevents the browser from fighting your scrollTo command
+            zoom_x_translated = Math.round(Math.max(0, Math.min(targetX, maxPossibleX)));
+            zoom_y_translated = Math.round(Math.max(0, Math.min(targetY, maxPossibleY)));
+                    
+            //Apply the final, safe coordinates preventing dancing x-axis effect on zoom out
             document.querySelector('#TreeData').scrollTo(zoom_x_translated, zoom_y_translated);
+
 
         }
         
@@ -3588,9 +3600,14 @@
 
 
         scroll_legend_into_view = function(node,full_screen_btn, node_TreeData){
+            console.log("Left value recalculated in scroll_legend_into_view()");    
+            
             if(node !== null){
-                node.style.left=`${node_TreeData.scrollLeft}px`
-                node.style.top=`${node_TreeData.scrollTop}px`
+                const x = Math.round(node_TreeData.scrollLeft);
+                const y = Math.round(node_TreeData.scrollTop);
+
+                node.style.left=`${x}px`
+                node.style.top=`${y}px`
                 full_screen_btn.style.right = `-${node_TreeData.scrollLeft}px`
                 full_screen_btn.style.top = `${node_TreeData.scrollTop}px`
 

--- a/html/table.html
+++ b/html/table.html
@@ -422,7 +422,10 @@
              * scale bar is slightly difficult to add, as the svg viewport dat only shows up AFTER rendering
              */
             
-             // --- Input Validation ---
+            const padding = { 
+                top: -2,    // Gap above the scale bar text
+            }
+                    // --- Input Validation ---
             try {
                 if (!svg || typeof svg.append !== 'function' || svg.empty()) {
                     throw new Error("Invalid 'svg' parameter: expected a D3 selection.");
@@ -443,7 +446,10 @@
                 console.error("drawScale() failed due to invalid input:", error.message);
                 return; // Exit early to avoid rendering with bad input
             }
-            const scaleBarGroup = svg.append("g").attr("id", "scale-bar-group") //group all svg path elements under single group
+            const scaleBarGroup = svg.append("g")
+                                     .attr("id", "scale-bar-group") //group all svg path elements under single group
+                                    .attr("transform", `translate(0, ${padding.top})`);
+            
             enableVerticalElementDrag(scaleBarGroup); //enables vertical drag of the scale bar
 
             let scale_bar_menu = `<div id="scale-bar-menu" class="d-flex flex-wrap p-1 align-items-center text-left" data-toggle="tooltip" data-placement="top" title="Turn scalebar on/off">
@@ -2135,6 +2141,11 @@
         // Create a subtree from the inner node selected in a tree
         let CustomSubTree = (event, data) => {
             console.debug("Subtree is being rendered")
+            const zoomSlider = document.querySelector('#zoom_slider');
+            const zoomValueLabel = document.querySelector('#zoom_slider_value');
+            zoomSlider.value = 1;
+            zoomValueLabel.textContent = "1";
+
             const isLegendActive = !$('#colour-legend').hasClass('d-none');
             console.debug("Legend is active:", isLegendActive);
             $("#legend_toggle").bootstrapToggle('off')
@@ -2152,7 +2163,7 @@
                 
                 console.debug(`New head node of the tree with ${totalNodes} nodes at distance ${copy_head_node.max_length} and ultrametric=${TREE_ULTRAMETRIC_P}`);
                 //if a tree is non-ultrametric then create a subtree with subtracted distances from the head node selected as root now
-                console.debug(copy_head_node)
+               
                 if (!TREE_ULTRAMETRIC_P){
                     const distanceToSubtract = copy_head_node.max_length;
                     const subtractDistance = (node, amount) => {
@@ -2181,6 +2192,7 @@
                 
                 let renderedTreePadding = svg_chart.style.paddingLeft || 0
                 svg_chart.style.paddingLeft = `${renderedTreePadding + TREE_OFFSET}px`
+            
 
                 $("#TreeData").append(svg_chart);
                 
@@ -3506,8 +3518,11 @@
             const tree_svg = document.querySelector('#TreeSVG')
             document.querySelector('#zoom_slider_value').textContent =  zoom_times 
 
+            const content_bbox = tree_svg.getBBox(); //content bounding box of the Tree SVG
+
             // Define the base coordinate width (unzoomed) including your offset
-            const base_coordinate_width = ORIGINAL_WIDTH_SVG + TREE_LEFT_MARGIN_VIEWBOX_OFFSET + 20;
+            const base_coordinate_width = Math.max(ORIGINAL_WIDTH_SVG + TREE_LEFT_MARGIN_VIEWBOX_OFFSET + 20,
+                                            content_bbox.width + content_bbox.x + 50); //20 for right margin padding
             const current_vb = tree_svg.viewBox.baseVal; //current viewBox values
             const base_coordinate_height = current_vb.height; //the unzoomed height of the tree.
 
@@ -3681,15 +3696,16 @@
         }    
 
         let select_deselect_nodes_by_field_value = (legend_node, column_index) => {
-
+            
             //find indices of filtered data in a metadata table
-            let indexes = data_table.rows( (idx, data, node) => {
-                if(data[column_index] === `${legend_node.getAttribute('data-fieldvalue')}` ){
-                    return true
-                }else{
-                    return false
-                }
-            } ).indexes()
+            let getIndexes = () => {
+                return data_table.rows((idx, data, node) => {
+                    return data[column_index] === `${legend_node.getAttribute('data-fieldvalue')}`;
+                }).indexes();
+            };
+
+            let indexes = getIndexes();
+
             
             let selected = legend_node.classList.contains('fw-bold') ? true : false
             
@@ -3700,6 +3716,20 @@
             }
 
             let selected_node_ids = data_table.cells(indexes,0).data();
+
+            // Reset metadata by removing filters if no IDs were found (metadata is likely filtered)
+            if (selected_node_ids.length === 0) {
+                data_table.clear();
+                data_table.rows.add(Array.from(ORIGINAL_DATA.values())).draw();
+                $("td").addClass("editable");
+                $("td:not(:first-child)").attr("contenteditable", true);
+                
+                // Refresh indices after reset
+                indexes = getIndexes();
+                selected_node_ids = data_table.cells(indexes, 0).data();
+            }
+            
+
             for(var i = 0; i < selected_node_ids.length; i++) {
                 let tree_node = document.querySelector( `[id='${selected_node_ids[i]}']`)
                 let [ele, circle, text] = SelectedNodes.getNodeData(tree_node);
@@ -3714,8 +3744,13 @@
                 }    
             }
             // Bring the terminal node into frame
-            terminal_node = document.querySelector(`[id=${selected_node_ids[selected_node_ids.length-1]}`);
-            terminal_node.scrollIntoView({block: "center", inline: "center"})
+            let lastId = selected_node_ids[selected_node_ids.length-1];
+            terminal_node = document.querySelector(`[id=${lastId}]`);
+            if (terminal_node) {
+                terminal_node.scrollIntoView({block: "center", inline: "center"})
+            }else{
+                console.warn(`Node with ID ${lastId} not found in DOM. Cannot scroll.`);
+            }    
             SelectedNodes.drawSelectedNodes();
             
         }
@@ -3839,7 +3874,14 @@
         }
 
 
-        export_tree_to_svg = function(){
+
+       
+        export_tree_to_svg = function(event){
+            if (event) {
+                event.preventDefault();
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+            }
             const date = new Date();
             let downloadLink = document.createElement("a");
             downloadLink.download = 'tree_snapshot_'+date.getDate()+'-'+
@@ -3855,12 +3897,14 @@
             svg.querySelector("#TreeSVG").style.overflow = "visible"
             const blob = serialize2svg(svg)[0];
             downloadLink.href = window.URL.createObjectURL(blob);
+            console.log(window.URL.createObjectURL(blob))
             downloadLink.click(); //Trigger a click on the element
             downloadLink.remove();               
         }
 
+
         /*Adapted from https://gist.github.com/tatsuyasusukida/1261585e3422da5645a1cbb9cf8813d6 and https://zooper.pages.dev/articles/how-to-convert-a-svg-to-png-using-canvas*/
-        export_tree_to_png = function(){
+        export_tree_to_png = function(event){
             
           let svg =  document.getElementById("TreeSVG").cloneNode(true); 
 
@@ -4312,12 +4356,12 @@
                                         title="Copy selected node IDs to your clipboard to paste into another application and optionally generate a text file" onclick="copy_ids_to_clipboard()" name="CopyIDs" id="copy-ids-button">
                                         <i class="bi bi-clipboard m-1"></i>IDs
                                     </button>
-                                    <button class="flex-grow-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
-                                        title="Export the tree to SVG." onclick="export_tree_to_svg()" id="export-tree-to-svg">
+                                    <button type="button" class="flex-grow-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
+                                        title="Export the tree to SVG." onclick="export_tree_to_svg(event)" id="export-tree-to-svg">
                                         <i class="bi bi-download m-1"></i> SVG
                                     </button>
-                                    <button class="flex-grow-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
-                                        title="Export the tree to PNG." onclick="export_tree_to_png()" id="export-tree-to-png">
+                                    <button type="button" class="flex-grow-1 btn-sm btn-primary text-break" data-toggle="tooltip" data-placement="top" 
+                                        title="Export the tree to PNG." onclick="export_tree_to_png(event)" id="export-tree-to-png">
                                         <i class="bi bi-download m-1"></i> PNG
                                     </button>
                                 </div>

--- a/html/table.html
+++ b/html/table.html
@@ -2,6 +2,15 @@
 <html>
 <head>
     <style>
+        body {
+            max-height: 100vh;
+            margin: 0;
+            padding: 0;
+            overflow: hidden; /* Prevents body scrollbars */
+            display: flex;
+            flex-direction: column;
+        }
+        
         .inline-block-child {
             display: inline-block;
         }
@@ -20,6 +29,12 @@
           position: relative;
           overflow: auto
         }
+
+        
+        #resizer-bar {
+            flex: 0 0 5px !important;
+            min-height: 5px;
+        }
         
         .tree-svg {
           height: auto;
@@ -28,7 +43,7 @@
           overflow: visible;
           margin-left: 1em; 
 
-    }
+        }
 
         .row.no-wrap {
             flex-wrap: nowrap; /*prevents the TreeData div with the svg tree to wrap around*/
@@ -2557,7 +2572,8 @@
             const treeData = document.querySelector('#TreeData');
             const menuButtons = document.querySelector('#tree_menu_buttons');
             const selectedNodes = document.querySelector('#SelectedNodes');
-            const metadataTable = document.querySelector('#ClusterInfo')
+            const metadataTable = document.querySelector('#ClusterInfo');
+
             if (!treeData || !menuButtons || !selectedNodes) return;
 
             const availableHeight = Math.abs(treeData.offsetHeight - menuButtons.clientHeight-12);
@@ -2883,7 +2899,6 @@
             const [minX, minY, width, height] = viewBoxAttr.split(/[\s,]+/).map(Number)
             // Update the width of the svg element
             //treeDataContainer.scrollLeft = newWidth;
-            console.log("The scroll left BEFORE is set to:", treeDataContainer.scrollLeft);
 
             svg.attr("width", newWidth)
                .attr("height", height)
@@ -2893,7 +2908,6 @@
             const maxScrollLeft = newWidth - treeDataContainer.clientWidth;
             treeDataContainer.scrollLeft = maxScrollLeft; //scroll to the right margin
 
-            console.log("The scroll left AFTER is set to:", treeDataContainer.scrollLeft);
           
         }
 
@@ -3638,7 +3652,6 @@
 
 
         scroll_legend_into_view = function(node,full_screen_btn, node_TreeData){
-            console.log("Left value recalculated in scroll_legend_into_view()");    
             
             if(node !== null){
                 const x = Math.round(node_TreeData.scrollLeft+10);
@@ -3969,9 +3982,12 @@
             document.querySelector('#ClusterInfo').addEventListener('hidden.bs.collapse', function () {
                 let heightMetaDiv = document.querySelector('#ClusterInfo>div').style.height
                 let heightTreeDataDiv = document.querySelector('#TreeData').style.height
+                let resizerHeight = document.querySelector('#resizer-bar').offsetHeight
                 let unitMatchTree = heightTreeDataDiv.match(/.?(\w{1,2})$/)
                 let unitMatchMeta = heightMetaDiv.match(/.?(\w{1,2})$/)
                 let unitTree = unitMatchTree ? unitMatchTree[1] : null;
+                let viewportHeight = window.visualViewport.height;
+                let maxAllowedHeight = window.innerHeight - resizerHeight - 10;
                 /*let unitMeta = unitMatchMeta ? unitMatchMeta[1] : null;
             
                 // Calculate the equivalent pixel value from vh
@@ -3980,11 +3996,15 @@
                     heightMetaDiv = (parseFloat(heightMetaDiv) / 100) * viewportHeight;
                     unitMeta="px"
                 }*/
-               
-                if(unitTree !== null){  
-                    document.querySelector('#TreeData').style.height= parseFloat(heightTreeDataDiv) + parseFloat(heightMetaDiv)+"px"
-                    document.querySelector('#control_panel').style.height = parseFloat(heightTreeDataDiv) + parseFloat(heightMetaDiv)+"px"
+                      
+                if(unitTree !== null){
+                    let calculatedHeight = parseFloat(heightTreeDataDiv) + parseFloat(heightMetaDiv)
+                    let finalHeight = Math.min(calculatedHeight, maxAllowedHeight);
+                    
+                    document.querySelector('#TreeData').style.height= finalHeight +"px"
+                    document.querySelector('#control_panel').style.height = finalHeight +"px"
                 }else{
+                    
                     document.querySelector('#TreeData').style.height=`${window.visualViewport.height-10}px`
                     document.querySelector('#control_panel').style.height=`${window.visualViewport.height-10}px`
                 }
@@ -4148,24 +4168,36 @@
         vertical_div_resize = function(event){
             event.preventDefault()
             let cursor_pos_init = event.y
+            const clusterInfo = document.querySelector('#ClusterInfo');
             metadata_panel = document.querySelector('#ClusterInfo>div')
             treeData_panel = document.querySelector('#TreeData')
             control_panel = document.querySelector('#control_panel')
+
             let metadata_panel_height_init = metadata_panel.getBoundingClientRect().height
             let treeData_panel_height_init = treeData_panel.getBoundingClientRect().height
             let control_panel_height_init = control_panel.getBoundingClientRect().height
             document.addEventListener('mousemove', resize, false)
             document.addEventListener('mouseup', stop_resize, false)
+
+            //Only uncollapse if it was hidden and do not use bsCollapse.show(), the animation will conflict with the mouse move.
+            if (!clusterInfo.classList.contains('show')) {
+                clusterInfo.classList.add('show'); // Force the class on immediately with no animation
+                metadata_panel.style.height = '0px'; // Ensure element starts at 0 height for correct math
+            }
+
             function resize(event){
                 event.stopPropagation();
                 const dy = event.y - cursor_pos_init  
                 metadata_panel.style.height = metadata_panel_height_init - dy+'px'
-                treeData_panel.style.height  = treeData_panel_height_init + dy+'px'
-                control_panel.style.height = control_panel_height_init + dy+'px'
+                treeData_panel.style.height  = treeData_panel_height_init + dy +'px'
+                control_panel.style.height = control_panel_height_init + dy +'px'
             }
             function stop_resize(event){
                 document.removeEventListener('mousemove', resize)
                 document.querySelector('#SelectedNodes').style.Height = `${document.querySelector('#TreeData').offsetHeight - document.querySelector('#tree_menu_buttons').offsetHeight}px`
+            
+                
+
             }   
             
         }
@@ -4254,7 +4286,7 @@
     </script>
 </head>
     <body>
-        <div class="container-fluid m-0">
+        <div id="top-section-container" class="container-fluid m-0">
             <div class="row no-wrap"> <!-- id="TreeSelections" style=""-->
                 <div id="control_panel" class="col-2 border border-primary px-1 position-relative">
                     <div id="tree_menu_buttons" class="row m-0">
@@ -4442,11 +4474,14 @@
                 
         </div>
         
-        <div class="row m-0" style="height:5px;background-color: #0d6efd; position: relative">
+        <div id="resizer-bar" class="row m-0" style="background-color: #0d6efd; 
+        position: relative;">
                 <a  href="#" data-bs-toggle="collapse" data-bs-target="#ClusterInfo"></a>
                 <div class="p-0" onmousedown="vertical_div_resize(event)" 
-                    style="position:absolute; cursor: ns-resize; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); border-radius: 3px; left:50%; 
-                    background-color: #dc3545; width:50px; height:10px; z-index: 2;">
+                    style="position:absolute; cursor: ns-resize; 
+                    box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); border-radius: 3px; left:50%; 
+                    background-color: #dc3545; width:50px; height:10px; z-index: 2;
+                    left: calc(50% - 25px); top: calc(50% - 5px);">
                 </div>
         </div>
         

--- a/html/table.html
+++ b/html/table.html
@@ -2874,8 +2874,8 @@
             const [minX, minY, width, height] = viewBoxAttr.split(/[\s,]+/).map(Number)
             // Update the width of the svg element
             svg.attr("width", newWidth)
-               .attr("height", newHeight)
-               .attr("viewBox", `${minX} ${minY} ${newWidth} ${newHeight}`)
+               .attr("height", height)
+               .attr("viewBox", `${minX} ${minY} ${newWidth} ${height}`)
             svg.style.overflow = "scroll";
         
 

--- a/html/table.html
+++ b/html/table.html
@@ -184,6 +184,8 @@
 
     </style>
     <meta charset="UTF-8">
+    <meta name="application-name" content="ArborView">
+    <meta name="version" content="0.1.3"> <!-- Update version as needed -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ArborView</title> 
 
@@ -2743,14 +2745,29 @@
         };
 
         let SubsetTable = () => {
+            let totalSamples = data_table.rows().count();;
             let filtered = data_table.data().filter((value, idx) => {
                 return SelectedNodes.nodes.has(value[ID_FIELD]);
             });
+            let remainingSamples = filtered.length;
+            let filteredOutSamplesCount = totalSamples - remainingSamples;
       
             data_table.clear();
             data_table.rows.add(filtered).draw();
             $("td").addClass("editable");
             $("td:not(:first-child)").attr("contenteditable", true);
+
+            Swal.fire({
+                title: 'Metadata Table Subsetted based on Selected Nodes',
+                html: `<b>${remainingSamples}</b> samples kept out of <b>${totalSamples}</b>.<br>` + 
+                    `<small class="text-muted"><b>${filteredOutSamplesCount}</b> samples were filtered out.</small>`,
+                icon: 'success',
+                timer: 5000,
+                timerProgressBar: true,
+                showConfirmButton: false,
+                toast: true,
+                position: 'top-end'
+            });
 
         };
 

--- a/html/table.html
+++ b/html/table.html
@@ -2637,17 +2637,25 @@
 
             let node_leg = $("#colour-legend")
             node_leg.empty()
-            node_leg.append(`<div id="drag_legend_button" onmousedown="dragDivByMouse(event)" class="w-100" style="height:5px; background-color:blue; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); cursor: all-scroll;"></div>`)
+            //Add the drag handle
+            node_leg.append(`<div id="drag_legend_button" onmousedown="dragDivByMouse(event)" class="w-100" style="height:8px; background-color:blue; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); cursor: all-scroll;"></div>`)
             
+                        
+
+            const columnName = TABLE_HEADERS[column_index] || `Unlabeled (column #${Number(column_index)+1})` //in case no column name is provided
+            node_leg.append(`<div class="p-2 border-bottom bg-light text-center">
+                                <strong>${columnName}</strong>
+                            </div>`);
+
             for(const item of array_tuples.filter(tuple => tuple[0] !== '')){ //[field_value, hex_colour]
                 let row_legend_node = $(`<div class="d-flex p-1 border-bottom flex-nowrap align-items-center legend-element"></div>`)
                 let field_value=item[0]
                 let count = (value2samples[field_value] || []).length;
-                //if(field_value === ''){field_value="Not defined"}
+                //if(field_value === ''){field_value="Not defined"}  
                 row_legend_node.append(`
                 <input type="color" value="${item[1]}" data-sampleID="${value2samples[item[0]].join(',')}"  onchange="changeLegendItemColour(this)" 
                 style="width: 20px; height:20px; padding: 1px; border: 1px solid black"></input>\n
-                <small onclick="select_deselect_nodes_by_field_value(this, ${column_index})" 
+                <small data-fieldvalue="${field_value}" onclick="select_deselect_nodes_by_field_value(this, ${column_index})" 
                 style="padding-left:5px">${field_value} (${count})</small>`)
                 node_leg.append(row_legend_node)
             }
@@ -2864,7 +2872,7 @@
 
 
             const newWidth = treeContainer.node().getBBox().width
-            const newHeight = treeContainer.node().getBBox().height+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
+            //const newHeight = treeContainer.node().getBBox().height+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
         
             const viewBoxAttr = svg.attr("viewBox")
             if (!viewBoxAttr) {
@@ -3649,7 +3657,7 @@
 
             //find indices of filtered data in a metadata table
             let indexes = data_table.rows( (idx, data, node) => {
-                if(data[column_index] === `${legend_node.textContent}` ){
+                if(data[column_index] === `${legend_node.getAttribute('data-fieldvalue')}` ){
                     return true
                 }else{
                     return false

--- a/html/table.html
+++ b/html/table.html
@@ -2871,7 +2871,7 @@
  
 
 
-            const newWidth = treeContainer.node().getBBox().width
+            const newWidth = treeContainer.node().getBBox().width+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
             //const newHeight = treeContainer.node().getBBox().height+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
         
             const viewBoxAttr = svg.attr("viewBox")
@@ -2885,8 +2885,6 @@
                .attr("height", height)
                .attr("viewBox", `${minX} ${minY} ${newWidth} ${height}`)
             svg.style.overflow = "scroll";
-        
-
 
           
         }
@@ -3637,7 +3635,7 @@
             if(node !== null){
                 const x = Math.round(node_TreeData.scrollLeft);
                 const y = Math.round(node_TreeData.scrollTop);
-
+             
                 node.style.left=`${x}px`
                 node.style.top=`${y}px`
                 full_screen_btn.style.right = `-${node_TreeData.scrollLeft}px`

--- a/html/table.html
+++ b/html/table.html
@@ -235,8 +235,8 @@
         var ORIGINAL_DATA = null;
         var ORIGINAL_VIEW_BOX = null;
         var ORIGINAL_WIDTH_SVG = 0;  
-        var LAST_MOVE_X = 0;
-        var LAST_MOVE_Y = 0;
+        var LAST_SCROLL_X = 0; // Store last scroll x-position making legend position updates smarter
+        var LAST_SCROLL_Y = 0; // Store last scroll y-position  making legend position updates smarter
         var SHOW_BRANCH_LENGTHS = true;
         var SHOW_METADATA_IN_NAME = false;
         var LINE_THICKNESS = 2.0;  
@@ -2816,6 +2816,7 @@
             
             const svg = d3.select("#TreeSVG")
             const treeContainer = svg.select('g[cursor="pointer"][pointer-events="all"]')
+            const treeDataContainer = document.querySelector('#TreeData');
             const svgAttrWidth = svg.attr("width")
             const oldWidth = treeContainer.node().getBBox().width
 
@@ -2871,7 +2872,7 @@
  
 
 
-            const newWidth = treeContainer.node().getBBox().width+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
+            const newWidth = treeContainer.node().getBBox().width+50 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
             //const newHeight = treeContainer.node().getBBox().height+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
         
             const viewBoxAttr = svg.attr("viewBox")
@@ -2881,11 +2882,18 @@
             }
             const [minX, minY, width, height] = viewBoxAttr.split(/[\s,]+/).map(Number)
             // Update the width of the svg element
+            //treeDataContainer.scrollLeft = newWidth;
+            console.log("The scroll left BEFORE is set to:", treeDataContainer.scrollLeft);
+
             svg.attr("width", newWidth)
                .attr("height", height)
                .attr("viewBox", `${minX} ${minY} ${newWidth} ${height}`)
             svg.style.overflow = "scroll";
 
+            const maxScrollLeft = newWidth - treeDataContainer.clientWidth;
+            treeDataContainer.scrollLeft = maxScrollLeft; //scroll to the right margin
+
+            console.log("The scroll left AFTER is set to:", treeDataContainer.scrollLeft);
           
         }
 
@@ -3633,8 +3641,16 @@
             console.log("Left value recalculated in scroll_legend_into_view()");    
             
             if(node !== null){
-                const x = Math.round(node_TreeData.scrollLeft);
-                const y = Math.round(node_TreeData.scrollTop);
+                const x = Math.round(node_TreeData.scrollLeft+10);
+                const y = Math.round(node_TreeData.scrollTop+10);
+
+                // Skip if the movement is less than 5px (small)
+                if (Math.abs(x - LAST_SCROLL_X) < 5 && Math.abs(y - LAST_SCROLL_Y) < 2) {
+                    return;
+                }
+
+                LAST_SCROLL_X = x;
+                LAST_SCROLL_Y = y;
              
                 node.style.left=`${x}px`
                 node.style.top=`${y}px`
@@ -4184,6 +4200,12 @@
     dragDivByMouse = function(event) {
         const legend_div = document.querySelector('#colour-legend');
         const control_panel_div = document.querySelector("#control_panel");
+        const treeDataContainer = document.querySelector('#TreeData');
+
+        //Current SVG TreeData scroll positions to adjust for scrolling during drag
+        const scrollY = treeDataContainer.scrollTop;
+        const scrollX = treeDataContainer.scrollLeft;
+        
 
         // Get bounding box of the legend
         const rect = legend_div.getBoundingClientRect();
@@ -4191,6 +4213,9 @@
         // Calculate initial grab offset (mouse position within the div)
         const grabOffsetX = event.clientX - rect.left;
         const grabOffsetY = event.clientY - rect.top;
+
+
+        const tree = document.querySelector('#TreeData');
 
         // Store control panel width
         let controlPanelOffset = control_panel_div.offsetWidth;
@@ -4206,8 +4231,8 @@
             e.preventDefault();
 
             // Calculate new position, accounting for grab offset and control panel width
-            const newLeft = e.clientX - grabOffsetX - controlPanelOffset;
-            const newTop = e.clientY - grabOffsetY;
+            const newLeft = e.clientX - grabOffsetX - controlPanelOffset + scrollX;
+            const newTop = e.clientY - grabOffsetY + scrollY;
 
             legend_div.style.left = newLeft + "px";
             legend_div.style.top = newTop + "px";

--- a/html/table.html
+++ b/html/table.html
@@ -40,9 +40,14 @@
             width:fit-content;
         }
 
-        #metadata_filter, #metadata_paginate{ 
+        #metadata_filter, #metadata_paginate{ /*Search and clear filters button of metadata table */
             position: sticky;
             right: 0;
+        }
+
+        #metadata_length { /*show x entries filter of metadata table */
+            position: sticky;
+            left: 0;  
         }
        
         

--- a/html/table.html
+++ b/html/table.html
@@ -225,6 +225,7 @@
         const TREE_OFFSET = 100;
         const TREE_LEFT_MARGIN_VIEWBOX_OFFSET = 30; //Space to accommodate near the root inner node labels
         var METDATA_TABLE_NON_FULL_SCREEEN_HEIGTH = null; //before changing to full screen mode save the current size of the metadata table
+        var LAST_METADATA_COLUMN_SELECTED = null;   //last metadata column selected for legend rendering. useful for subtree legend generation
         var NEWICK = null;
         var tree_root = null;
         var METADATA = null;
@@ -2119,6 +2120,8 @@
         // Create a subtree from the inner node selected in a tree
         let CustomSubTree = (event, data) => {
             console.debug("Subtree is being rendered")
+            const isLegendActive = !$('#colour-legend').hasClass('d-none');
+            console.debug("Legend is active:", isLegendActive);
             $("#legend_toggle").bootstrapToggle('off')
             SelectedNodes.drawSelectedNodes();
             $('#colour-legend').empty()
@@ -2165,6 +2168,12 @@
                 svg_chart.style.paddingLeft = `${renderedTreePadding + TREE_OFFSET}px`
 
                 $("#TreeData").append(svg_chart);
+                
+                if (isLegendActive && LAST_METADATA_COLUMN_SELECTED !== null) {
+                    // Regenerate the legend for the subtree using last selected field
+                    colour_by_element(LAST_METADATA_COLUMN_SELECTED);
+                }
+
                 $(".leaf-node").each((i, elm) => {
                     // Maintain colour of already selected nodes
                     let [parent, circle, text] = SelectedNodes.getNodeData(elm);
@@ -2296,7 +2305,7 @@
               }
               maxIDLength = Math.max(key.length, maxIDLength);
               const selectedValues = selected_indexes.map((i) => {
-                                        let row_label = String(row[i] || "NA").trim(); 
+                                        let row_label = String(row[i] ?? "").trim();  // ?? preserves '0', empty strings, and false. It only replaces null/undefined.
                                         /** @remarks
                                           fromCodePoint retrieves the the horizontal unicode elipse so that the charactar is rendered nicely.
                                         */
@@ -2629,16 +2638,17 @@
             let node_leg = $("#colour-legend")
             node_leg.empty()
             node_leg.append(`<div id="drag_legend_button" onmousedown="dragDivByMouse(event)" class="w-100" style="height:5px; background-color:blue; box-shadow: 1px 1px 1px 1px rgba(0,0,0,.8); cursor: all-scroll;"></div>`)
-
-            for(const item of array_tuples){ //[field_value, hex_colour]
+            
+            for(const item of array_tuples.filter(tuple => tuple[0] !== '')){ //[field_value, hex_colour]
                 let row_legend_node = $(`<div class="d-flex p-1 border-bottom flex-nowrap align-items-center legend-element"></div>`)
                 let field_value=item[0]
-                if(field_value === ''){field_value="Not defined"}
+                let count = (value2samples[field_value] || []).length;
+                //if(field_value === ''){field_value="Not defined"}
                 row_legend_node.append(`
                 <input type="color" value="${item[1]}" data-sampleID="${value2samples[item[0]].join(',')}"  onchange="changeLegendItemColour(this)" 
                 style="width: 20px; height:20px; padding: 1px; border: 1px solid black"></input>\n
                 <small onclick="select_deselect_nodes_by_field_value(this, ${column_index})" 
-                style="padding-left:5px">${field_value}</small>`)
+                style="padding-left:5px">${field_value} (${count})</small>`)
                 node_leg.append(row_legend_node)
             }
             document.querySelector('#colour-legend').classList.remove("d-none");
@@ -2824,6 +2834,7 @@
             svg.selectAll("g.leaf-node").each(function () {
                 const g = d3.select(this);
                 const nodeId = this.id;
+                
                 if (isEmpty) {
                     newLabel = `${nodeId}`;
                 } else {
@@ -2835,6 +2846,7 @@
                       trimEnd()  would work, but if we had more options for justifying text in 
                       the future in may create some problems.
                     */
+                    
                     newLabel = hasValue ? `${joinedFields}` : nodeId;
                 }
                 g.selectAll("text")
@@ -3053,6 +3065,7 @@
         
         
         let colour_by_element = (ele) => {
+            LAST_METADATA_COLUMN_SELECTED = ele;
             // Create a legend for the column selected
             if(tree_root === null){
                 // TODO add pop up
@@ -3061,6 +3074,7 @@
             }
 
             let col_index = ele.id;
+            
             $("#legend_toggle").bootstrapToggle('on')
 
             let unq_data = new Set();
@@ -3069,7 +3083,7 @@
             })
 
 
-            // Need to create groupings of the each set of ID's belonging to each value grouping
+            // Need to create GLOBAL TREE groupings of the each set of ID's belonging to each value grouping
             let break_down_values = Array.from(unq_data);
             break_down_values.sort()
             
@@ -3134,35 +3148,45 @@
             //colour each leaf nodes with the selected colour
             let colour_idx = 0;
             colour_legend.length = 0; // clear out old data, so new legend created each time
+            
             for (const nodeId of SelectedNodes.nodes) {
                 console.debug(nodeId); // This will log each node ID in the Set
             }
+            // This local object will hold only the nodes currently in the DOM
+            // Relevant when generating the legend for subtrees 
+            let visible_breakdown = [];
             for(const item in break_down_values){
+                let nodes_found_for_this_category = []; //checks if node exists in DOM now
+                if (item === "" || item === null) continue; //Skip empty field values (leaves them uncoloured/hidden from legend)
+
                 break_down_values[item].forEach((x, i) => {
-                  
-                    try{
-                        let current_item = document.querySelector(`[id='${x}']`);
-                        let [elem, circle, text] = SelectedNodes.getNodeData(current_item);
-                        if(SelectedNodes.nodes.has(x)){
-                            circle.dataset.oldfill = colours[colour_idx];
-                        }else{
-                            if (circle.style.fill !== "") {
-                                circle.dataset.oldfill = circle.style.fill;
-                            }else{
-                                circle.dataset.oldfill = SelectedNodes.getDefaultColour();
-                            }    
+                    
+                    //check if the node exists in the DOM (e.g. subtree case)
+                    if(document.getElementById(x)){
+                    
+                        try{
+                            let current_item = document.querySelector(`[id='${x}']`);
+                            let [elem, circle, text] = SelectedNodes.getNodeData(current_item);
+                            nodes_found_for_this_category.push(x);
+                            circle.dataset.oldfill = circle.style.fill || SelectedNodes.getDefaultColour();
                             circle.style.fill = colours[colour_idx];
+                                
+                        }catch(error){
+                                console.error("Could not find node ", x, " in DOM");
+                                console.error(error); 
                         }
-                        
-                    }catch(error){
-                        console.error("Could not find ", x, " In DOM");
-                        console.error(error); 
                     }
                 });
-                colour_legend.push([item, colours[colour_idx]])
-                colour_idx++;
+
+       
+                if (nodes_found_for_this_category.length > 0) {
+                    colour_legend.push([item, colours[colour_idx]])
+                    visible_breakdown[item] = nodes_found_for_this_category;
+                    colour_idx++;
+                }
             }
-            CreateNodeLegend(colour_legend, col_index, break_down_values);    
+         
+            CreateNodeLegend(colour_legend, col_index, visible_breakdown);    
 
         };
         
@@ -3478,7 +3502,6 @@
             // This is what makes the tree actually look bigger inside the new width/height
             tree_svg.setAttribute("viewBox", `${-TREE_LEFT_MARGIN_VIEWBOX_OFFSET} ${current_vb.y} ${base_coordinate_width} ${base_coordinate_height}`);
 
-
             // Calculate the scale change factor for width and height
             const scaleChangeX = new_width / prev_width;
             const scaleChangeY = new_height / prev_height; 
@@ -3492,7 +3515,7 @@
             const maxPossibleX = new_width - view_w;
             const maxPossibleY = new_height - view_h;
 
-            // Calculate the "Ideal" scroll target.
+            // Calculate the theoretical scroll target that does not care if the result is possible given screen dims
             let targetX = (prev_x_scroll_pos + view_w / 2) * scaleChangeX - (view_w / 2);
             let targetY = (prev_y_scroll_pos + view_h / 2) * scaleChangeY - (view_h / 2);
 
@@ -3500,7 +3523,7 @@
             zoom_x_translated = Math.round(Math.max(0, Math.min(targetX, maxPossibleX)));
             zoom_y_translated = Math.round(Math.max(0, Math.min(targetY, maxPossibleY)));
                     
-            //Apply the final, safe coordinates preventing dancing x-axis effect on zoom out
+            //Apply the final, safe coordinates preventing x-axis sliding effect on zoom out
             document.querySelector('#TreeData').scrollTo(zoom_x_translated, zoom_y_translated);
 
 

--- a/html/table.html
+++ b/html/table.html
@@ -35,6 +35,16 @@
             flex: 0 0 5px !important;
             min-height: 5px;
         }
+
+        #metadata_wrapper{
+            width:fit-content;
+        }
+
+        #metadata_filter, #metadata_paginate{ 
+            position: sticky;
+            right: 0;
+        }
+       
         
         .tree-svg {
           height: auto;
@@ -137,7 +147,6 @@
     
         .dataTables_filter {
             position: relative;
-            margin-right: 24px;
         }
         .dataTables_wrapper .dataTables_filter input{
             border-radius: 20px !important;
@@ -2492,6 +2501,8 @@
                 //icon.id="tree_fullscreen_btn"
                 //icon.onclick="tree_full_screen_mode()"
 
+                $('#metadata_length').addClass('p-1');
+
                 let html=document.createElement("div");
                 html.className = "paginate_button displayAll"
                 html.id = "paginate_button_all"
@@ -2500,15 +2511,6 @@
                     document.querySelector("#metadata_paginate").appendChild(html)
                 }
 
-                let maximize_button_html=document.createElement("i");
-                maximize_button_html.style = "position:absolute; top:0; right: 0; cursor: pointer; color:blue; margin-right:1px"
-                maximize_button_html.className="d-flex fs-5 bi-arrow-up-right-square"
-                maximize_button_html.id = "metadata_fullscreen_btn"
-                maximize_button_html.setAttribute("onclick", "metadata_full_screen_mode()")
-                if(document.querySelector("#metadata_fullscreen_btn") === null){
-                    document.querySelector("#metadata_wrapper").appendChild(maximize_button_html)
-                }    
-            
 
                 $('.paginate_button.displayAll:not(.disabled)', this.api().table().container())          
                 .on('click', function(){
@@ -2563,6 +2565,15 @@
                     });
 
             $('#metadata_filter').append(clearBtn);
+
+            let maximize_button_html=document.createElement("i");
+                maximize_button_html.style = "cursor: pointer; color:blue; margin-right:1px"
+                maximize_button_html.className="d-inline-flex p-1 fs-5 bi-arrow-up-right-square"
+                maximize_button_html.id = "metadata_fullscreen_btn"
+                maximize_button_html.setAttribute("onclick", "metadata_full_screen_mode()")
+                if(document.querySelector("#metadata_fullscreen_btn") === null){
+                    document.querySelector("#metadata_filter").appendChild(maximize_button_html);
+                }
             
             // TODO initializing table from json object would minimize copies
             // Saving data as a map, to allow for updating of metadata
@@ -4031,8 +4042,6 @@
 
         
         document.addEventListener("DOMContentLoaded",()=>{
-            let button = document.querySelector('#tree_fullscreen_btn')
-
            /**
              * Handles dynamic layout adjustments when the #ClusterInfo section is shown or hidden.
              *

--- a/html/table.html
+++ b/html/table.html
@@ -2864,7 +2864,8 @@
 
 
             const newWidth = treeContainer.node().getBBox().width
-            const newHeight = treeContainer.node().getBBox().height
+            const newHeight = treeContainer.node().getBBox().height+20 // add some padding as calculates the coordinates of the paths and shapes, but it does not include the width of the strokes
+        
             const viewBoxAttr = svg.attr("viewBox")
             if (!viewBoxAttr) {
                 console.warn("viewBox not yet initialized by chart function.");


### PR DESCRIPTION
## Main fixes and highlights 
- Legend stays visible and refreshes automatically when viewing a subtree.
- Fixed tree zoom functionality to ensure it works correctly on zoom out.
- Category counts now update to reflect only the nodes currently visible.
- Metadata labels preserve original zeros and blanks instead of forcing "NA" in legend and leaf nodes as requested. So metadata values are in sync with these parts of the application
- Automatically hides legend items not found in the current subtree
- Remembers the active color column to keep the legend regenrated when subtree is rendered across  tree views.
- Resolved viewport alignment by fixing the 30px left-margin offset to prevent value cropping upon newick data injection such as large numbers of inner nodes